### PR TITLE
 Implement parsing of variable definitions again

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Definitions.kt
@@ -13,21 +13,10 @@ import com.github.derg.transpiler.core.Name
 enum class Visibility
 {
     /**
-     * The object is visible to anything in the source code, no matter in which module or package it resides. Any part
-     * of the source code may include the object and access it without issues.
-     */
-    EXPOSED,
-    
-    /**
      * The object is accessible to everything within the same module as the object was declared in. The object will not
      * be visible to anything outside the current module.
      */
     PUBLIC,
-    
-    /**
-     * TODO: Reserved for future expansion.
-     */
-    PROTECTED,
     
     /**
      * The object is only accessible to the current type in which the object was declared. For example, a private

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
@@ -31,6 +31,7 @@ data class Keyword(val type: Type) : Token()
         IF("if"),
         IN("in"),
         MUT("mut"),
+        PUB("pub"),
         TRUE("true"),
         TYPE("type"),
         VAL("val"),

--- a/src/main/kotlin/com/github/derg/transpiler/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/Parser.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.parser
 
+import com.github.derg.transpiler.lexer.Keyword
 import com.github.derg.transpiler.lexer.Operator
 import com.github.derg.transpiler.lexer.Structure
 import com.github.derg.transpiler.lexer.Token
@@ -35,12 +36,14 @@ sealed class ParseError
     object End : ParseError()
     
     // The data acquired from the context has the wrong format
+    data class NotKeyword(val token: Token) : ParseError()
     data class NotOperator(val token: Token) : ParseError()
     data class NotStructure(val token: Token) : ParseError()
     data class NotIdentifier(val token: Token) : ParseError()
     data class NotExpression(val token: Token) : ParseError()
     
     // The data acquired from the context has the wrong value
+    data class WrongKeyword(val expected: Set<Keyword.Type>, val actual: Keyword.Type) : ParseError()
     data class WrongOperator(val expected: Set<Operator.Type>, val actual: Operator.Type) : ParseError()
     data class WrongStructure(val expected: Set<Structure.Type>, val actual: Structure.Type) : ParseError()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
@@ -1,15 +1,59 @@
 package com.github.derg.transpiler.parser.patterns
 
+import com.github.derg.transpiler.ast.Expression
+import com.github.derg.transpiler.ast.Mutability
 import com.github.derg.transpiler.ast.Variable
+import com.github.derg.transpiler.ast.Visibility
+import com.github.derg.transpiler.core.Name
+import com.github.derg.transpiler.lexer.Keyword
+import com.github.derg.transpiler.lexer.Keyword.Type.*
+import com.github.derg.transpiler.lexer.Operator
 import com.github.derg.transpiler.parser.Context
 import com.github.derg.transpiler.parser.ParseError
 import com.github.derg.transpiler.parser.Parser
 import com.github.derg.transpiler.util.Result
+import com.github.derg.transpiler.util.failureOf
+import com.github.derg.transpiler.util.toSuccess
+import com.github.derg.transpiler.util.valueOr
 
 object ParserVariableDefinition : Parser<Variable>
 {
+    private val pattern = ParserSequence(
+        ParserAllOf(
+            "visibility" to ParserOptional(ParserKeyword(PUB)),
+            "mutability" to ParserKeyword(VAL, VAR, MUT),
+        ),
+        ParserIdentifier,
+        ParserOperator(Operator.Type.ASSIGN),
+        ParserExpression,
+    )
+    
     override fun parse(context: Context): Result<Variable, ParseError>
     {
-        TODO("Not yet implemented")
+        val result = pattern.parse(context).valueOr { return failureOf(it) }
+        val keywords = result[0] as Map<String, Keyword.Type?>
+        val name = result[1] as Name
+        val type = null
+        val value = result[3] as Expression
+        val visibility = visibilityOf(keywords["visibility"])
+        val mutability = mutabilityOf(keywords["mutability"]!!)
+        
+        return Variable(name = name, type = type, value = value, visibility = visibility, mutability = mutability)
+            .toSuccess()
+    }
+    
+    private fun visibilityOf(keyword: Keyword.Type?) = when (keyword)
+    {
+        PUB  -> Visibility.PUBLIC
+        null -> Visibility.PRIVATE
+        else -> throw IllegalStateException("Illegal keyword $keyword when parsing variable visibility")
+    }
+    
+    private fun mutabilityOf(keyword: Keyword.Type) = when (keyword)
+    {
+        VAL  -> Mutability.VALUE
+        VAR  -> Mutability.VARYING
+        MUT  -> Mutability.MUTABLE
+        else -> throw IllegalStateException("Illegal keyword $keyword when parsing variable mutability")
     }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
@@ -1,0 +1,15 @@
+package com.github.derg.transpiler.parser.patterns
+
+import com.github.derg.transpiler.ast.Variable
+import com.github.derg.transpiler.parser.Context
+import com.github.derg.transpiler.parser.ParseError
+import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.util.Result
+
+object ParserVariableDefinition : Parser<Variable>
+{
+    override fun parse(context: Context): Result<Variable, ParseError>
+    {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Tokens.kt
@@ -38,7 +38,16 @@ class ParserKeyword(private val types: Set<Keyword.Type> = emptySet()) : Parser<
     /** Helper for specifying all keyword [types] which are accepted by this parser. */
     constructor(vararg types: Keyword.Type) : this(types.toSet())
     
-    override fun parse(context: Context): Result<Keyword.Type, ParseError> = TODO()
+    override fun parse(context: Context): Result<Keyword.Type, ParseError>
+    {
+        context.reset()
+        val token = context.next() ?: return failureOf(ParseError.End)
+        val keyword = token as? Keyword ?: return failureOf(ParseError.NotKeyword(token))
+        if (types.isNotEmpty() && keyword.type !in types)
+            return failureOf(ParseError.WrongKeyword(types, keyword.type))
+        context.commit()
+        return successOf(keyword.type)
+    }
 }
 
 /**

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -1,27 +1,77 @@
 package com.github.derg.transpiler.parser
 
-import com.github.derg.transpiler.ast.Access
-import com.github.derg.transpiler.ast.Parameter
-import com.github.derg.transpiler.ast.Value
+import com.github.derg.transpiler.ast.*
+import com.github.derg.transpiler.core.Name
 import com.github.derg.transpiler.lexer.Token
 import com.github.derg.transpiler.lexer.tokenize
 import com.github.derg.transpiler.util.successOf
 import com.github.derg.transpiler.util.toFailure
 import kotlin.test.assertEquals
 
-internal val Boolean.value: Value.Bool get() = Value.Bool(this)
-internal val Int.value: Value.Real get() = Value.Real(toBigDecimal(), null)
-internal val Int.parameter: Parameter get() = Parameter(null, value)
-internal val String.value: Value.Text get() = Value.Text(this, null)
-internal val String.variable: Access.Variable get() = Access.Variable(this)
-internal val String.function: Access.Function get() = Access.Function(this, emptyList())
+/**
+ * Converts [this] value into a literal expression if possible. The expression can only be generated from numeric,
+ * boolean, and string values.
+ */
+fun Any.toLit(type: Name? = null): Expression = when (this)
+{
+    is Boolean    -> Value.Bool(this)
+    is Double     -> Value.Real(toBigDecimal(), type)
+    is Float      -> Value.Real(toBigDecimal(), type)
+    is Int        -> Value.Real(toBigDecimal(), type)
+    is String     -> Value.Text(this, type)
+    is Expression -> this
+    else          -> throw IllegalStateException("Cannot convert '$this' to an expression")
+}
+
+fun Name.toVar() = Access.Variable(this)
+fun Name.toFun(vararg parameters: Parameter) = Access.Function(this, parameters.toList())
+
+// Generates expressions from operations
+infix fun Any.opEq(that: Any) = Operator.Equal(toLit(), that.toLit())
+infix fun Any.opNe(that: Any) = Operator.NotEqual(toLit(), that.toLit())
+infix fun Any.opLe(that: Any) = Operator.LessEqual(toLit(), that.toLit())
+infix fun Any.opLt(that: Any) = Operator.Less(toLit(), that.toLit())
+infix fun Any.opGe(that: Any) = Operator.GreaterEqual(toLit(), that.toLit())
+infix fun Any.opGt(that: Any) = Operator.Greater(toLit(), that.toLit())
+infix fun Any.opTw(that: Any) = Operator.ThreeWay(toLit(), that.toLit())
+infix fun Any.opAnd(that: Any) = Operator.And(toLit(), that.toLit())
+infix fun Any.opOr(that: Any) = Operator.Or(toLit(), that.toLit())
+infix fun Any.opXor(that: Any) = Operator.Xor(toLit(), that.toLit())
+infix fun Any.opAdd(that: Any) = Operator.Add(toLit(), that.toLit())
+infix fun Any.opSub(that: Any) = Operator.Subtract(toLit(), that.toLit())
+infix fun Any.opMul(that: Any) = Operator.Multiply(toLit(), that.toLit())
+infix fun Any.opDiv(that: Any) = Operator.Divide(toLit(), that.toLit())
+infix fun Any.opMod(that: Any) = Operator.Modulo(toLit(), that.toLit())
+fun opNot(that: Any) = Operator.Not(that.toLit())
+fun opUnPlus(that: Any) = Operator.UnaryPlus(that.toLit())
+fun opUnMinus(that: Any) = Operator.UnaryMinus(that.toLit())
+
+// Generate other useful constructs
+fun Any.toPar(type: Name? = null) = Parameter(type, toLit())
+
+/**
+ * Generates variable definition from the provided input parameters.
+ */
+fun variableOf(
+    name: Name,
+    type: Name? = null,
+    value: Expression = 0.toLit(),
+    visibility: Visibility = Visibility.PRIVATE,
+    mutability: Mutability = Mutability.VALUE,
+) = Variable(
+    name = name,
+    type = type,
+    value = value,
+    visibility = visibility,
+    mutability = mutability,
+)
 
 /**
  * To simplify testing of the parsing of source code for any particular pattern [factory], a helper class is provided.
  * This tester class allows the developer to write clearer and more concise test cases when parsing specific source
  * code. Each source code snippet can be tailor-made to suit certain edge-cases.
  */
-class PatternTester<Type>(private val factory: () -> Parser<Type>)
+class ParserTester<Type>(private val factory: () -> Parser<Type>)
 {
     private lateinit var parser: Parser<Type>
     private lateinit var context: Context
@@ -30,7 +80,7 @@ class PatternTester<Type>(private val factory: () -> Parser<Type>)
     /**
      * Parses the input [source] code and stores the tokens and the context for further analysis.
      */
-    fun parse(source: String): PatternTester<Type>
+    fun parse(source: String): ParserTester<Type>
     {
         parser = factory()
         tokens = tokenize(source).map { it.data }
@@ -42,7 +92,7 @@ class PatternTester<Type>(private val factory: () -> Parser<Type>)
      * Expects the parsing to succeed. Whenever parsing succeeds, the context cursor is moved forwards any number of
      * steps, although when a specific pattern succeeds, the cursor is expected to land on a known [index].
      */
-    fun isGood(index: Int, value: Type): PatternTester<Type>
+    fun isGood(index: Int, value: Type): ParserTester<Type>
     {
         assertEquals(successOf(value), parser.parse(context))
         assertEquals(index, context.snapshot())
@@ -53,7 +103,7 @@ class PatternTester<Type>(private val factory: () -> Parser<Type>)
      * Expects the parsing to fail due to the given [error]. Whenever parsing fails, the context is not permitted to
      * move forwards; its cursor must remain fixed.
      */
-    fun isBad(function: (List<Token>) -> ParseError): PatternTester<Type>
+    fun isBad(function: (List<Token>) -> ParseError): ParserTester<Type>
     {
         assertEquals(function(tokens).toFailure(), parser.parse(context).also { context.reset() })
         assertEquals(0, context.snapshot())

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -54,14 +54,14 @@ fun Any.toPar(type: Name? = null) = Parameter(type, toLit())
  */
 fun variableOf(
     name: Name,
+    value: Any,
     type: Name? = null,
-    value: Expression = 0.toLit(),
     visibility: Visibility = Visibility.PRIVATE,
     mutability: Mutability = Mutability.VALUE,
 ) = Variable(
     name = name,
     type = type,
-    value = value,
+    value = value.toLit(),
     visibility = visibility,
     mutability = mutability,
 )

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestCore.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestCore.kt
@@ -31,6 +31,44 @@ class TestParserAnyOf
     }
 }
 
+class TestParserAllOf
+{
+    private val real = ParserRealExpression
+    private val bool = ParserBoolExpression
+    
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        val tester = ParserTester { ParserAllOf("real" to real, "bool" to bool) }
+        val expected = mapOf("real" to 3.toLit(), "bool" to true.toLit())
+        
+        tester.parse("3 true").isGood(2, expected)
+        tester.parse("true 3").isGood(2, expected)
+    }
+    
+    @Test
+    fun `Given valid token, when parsing with optionals, then correctly parsed`()
+    {
+        val tester = ParserTester { ParserAllOf("real" to real, "bool" to ParserOptional(bool)) }
+        
+        tester.parse("3").isGood(1, mapOf("real" to 3.toLit(), "bool" to null))
+        tester.parse("true 3").isGood(2, mapOf("real" to 3.toLit(), "bool" to true.toLit()))
+        tester.parse("3 true").isGood(2, mapOf("real" to 3.toLit(), "bool" to true.toLit()))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        val tester = ParserTester { ParserAllOf("real" to real, "bool" to bool) }
+        
+        tester.parse("").isBad { End }
+        tester.parse("3").isBad { End }
+        tester.parse("false").isBad { End }
+        tester.parse("2 if").isBad { NotExpression(it[1]) }
+        tester.parse("if").isBad { NotExpression(it[0]) }
+    }
+}
+
 class TestParserSequence
 {
     private val tester = ParserTester { ParserSequence(ParserRealExpression, ParserBoolExpression) }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestCore.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestCore.kt
@@ -3,8 +3,8 @@ package com.github.derg.transpiler.parser.patterns
 import com.github.derg.transpiler.lexer.Structure
 import com.github.derg.transpiler.parser.ParseError.End
 import com.github.derg.transpiler.parser.ParseError.NotExpression
-import com.github.derg.transpiler.parser.PatternTester
-import com.github.derg.transpiler.parser.value
+import com.github.derg.transpiler.parser.ParserTester
+import com.github.derg.transpiler.parser.toLit
 import org.junit.jupiter.api.Test
 
 class TestParserAnyOf
@@ -15,16 +15,16 @@ class TestParserAnyOf
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
-        val tester = PatternTester { ParserAnyOf(text, real) }
+        val tester = ParserTester { ParserAnyOf(text, real) }
         
-        tester.parse("7").isGood(1, 7.value)
-        tester.parse("\"foo\"").isGood(1, "foo".value)
+        tester.parse("7").isGood(1, 7.toLit())
+        tester.parse("\"foo\"").isGood(1, "foo".toLit())
     }
     
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        val tester = PatternTester { ParserAnyOf(text, real) }
+        val tester = ParserTester { ParserAnyOf(text, real) }
         
         tester.parse("").isBad { End }
         tester.parse("false").isBad { NotExpression(it[0]) }
@@ -33,12 +33,12 @@ class TestParserAnyOf
 
 class TestParserSequence
 {
-    private val tester = PatternTester { ParserSequence(ParserRealExpression, ParserBoolExpression) }
+    private val tester = ParserTester { ParserSequence(ParserRealExpression, ParserBoolExpression) }
     
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
-        tester.parse("3 true").isGood(2, listOf(3.value, true.value))
+        tester.parse("3 true").isGood(2, listOf(3.toLit(), true.toLit()))
     }
     
     @Test
@@ -53,28 +53,28 @@ class TestParserSequence
 
 class TestParserRepeating
 {
-    private val tester = PatternTester { ParserRepeating(ParserRealExpression, ParserStructure(Structure.Type.COMMA)) }
+    private val tester = ParserTester { ParserRepeating(ParserRealExpression, ParserStructure(Structure.Type.COMMA)) }
     
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
         tester.parse("").isGood(0, emptyList())
-        tester.parse("1").isGood(1, listOf(1.value))
-        tester.parse("1, 2").isGood(3, listOf(1.value, 2.value))
-        tester.parse("1, 2, ").isGood(4, listOf(1.value, 2.value))
+        tester.parse("1").isGood(1, listOf(1.toLit()))
+        tester.parse("1, 2").isGood(3, listOf(1.toLit(), 2.toLit()))
+        tester.parse("1, 2, ").isGood(4, listOf(1.toLit(), 2.toLit()))
         tester.parse("if").isGood(0, emptyList())
     }
 }
 
 class TestParserOptional
 {
-    private val tester = PatternTester { ParserOptional(ParserRealExpression) }
+    private val tester = ParserTester { ParserOptional(ParserRealExpression) }
     
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
         tester.parse("").isGood(0, null)
         tester.parse("if").isGood(0, null)
-        tester.parse("7").isGood(1, 7.value)
+        tester.parse("7").isGood(1, 7.toLit())
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
@@ -1,0 +1,24 @@
+package com.github.derg.transpiler.parser.patterns
+
+import com.github.derg.transpiler.parser.ParseError
+import com.github.derg.transpiler.parser.ParserTester
+import com.github.derg.transpiler.parser.variableOf
+import org.junit.jupiter.api.Test
+
+class TestParseVariableDefinition
+{
+    private val tester = ParserTester { ParserVariableDefinition }
+    
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        tester.parse("true").isGood(1, variableOf("foo"))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.End }
+        tester.parse("if").isBad { ParseError.NotExpression(it[0]) }
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
@@ -1,6 +1,9 @@
 package com.github.derg.transpiler.parser.patterns
 
-import com.github.derg.transpiler.parser.ParseError
+import com.github.derg.transpiler.ast.Mutability
+import com.github.derg.transpiler.ast.Visibility
+import com.github.derg.transpiler.parser.ParseError.End
+import com.github.derg.transpiler.parser.ParseError.NotExpression
 import com.github.derg.transpiler.parser.ParserTester
 import com.github.derg.transpiler.parser.variableOf
 import org.junit.jupiter.api.Test
@@ -12,13 +15,22 @@ class TestParseVariableDefinition
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
-        tester.parse("true").isGood(1, variableOf("foo"))
+        // Mutability must be correctly parsed
+        tester.parse("val foo = 0").isGood(4, variableOf("foo", 0, mutability = Mutability.VALUE))
+        tester.parse("var foo = 0").isGood(4, variableOf("foo", 0, mutability = Mutability.VARYING))
+        tester.parse("mut foo = 0").isGood(4, variableOf("foo", 0, mutability = Mutability.MUTABLE))
+        
+        // Visibility must be correctly parsed
+        tester.parse("pub val foo = 0").isGood(5, variableOf("foo", 0, visibility = Visibility.PUBLIC))
+        tester.parse("    val foo = 0").isGood(4, variableOf("foo", 0, visibility = Visibility.PRIVATE))
     }
     
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        tester.parse("").isBad { ParseError.End }
-        tester.parse("if").isBad { ParseError.NotExpression(it[0]) }
+        tester.parse("").isBad { End }
+        tester.parse("val").isBad { End }
+        tester.parse("val foo =").isBad { End }
+        tester.parse("val foo = if").isBad { NotExpression(it[3]) }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
@@ -1,9 +1,6 @@
 package com.github.derg.transpiler.parser.patterns
 
-import com.github.derg.transpiler.ast.Access
 import com.github.derg.transpiler.ast.Assignment
-import com.github.derg.transpiler.ast.Operator
-import com.github.derg.transpiler.ast.Parameter
 import com.github.derg.transpiler.lexer.Structure.Type.CLOSE_PARENTHESIS
 import com.github.derg.transpiler.lexer.Structure.Type.OPEN_PARENTHESIS
 import com.github.derg.transpiler.parser.*
@@ -16,22 +13,22 @@ class TestParseExpressions
     @Nested
     inner class TestParserExpression
     {
-        private val tester = PatternTester { ParserExpression }
+        private val tester = ParserTester { ParserExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("true").isGood(1, true.value)
-            tester.parse("1").isGood(1, 1.value)
-            tester.parse("\"\"").isGood(1, "".value)
-            tester.parse("foo").isGood(1, "foo".variable)
-            tester.parse("(2)").isGood(3, 2.value)
-            tester.parse("f()").isGood(3, "f".function)
-            tester.parse("-1").isGood(2, Operator.UnaryMinus(1.value))
-            tester.parse("1 + 2").isGood(3, Operator.Add(1.value, 2.value))
-            tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.value))
+            tester.parse("true").isGood(1, true.toLit())
+            tester.parse("1").isGood(1, 1.toLit())
+            tester.parse("\"\"").isGood(1, "".toLit())
+            tester.parse("foo").isGood(1, "foo".toVar())
+            tester.parse("(2)").isGood(3, 2.toLit())
+            tester.parse("f()").isGood(3, "f".toFun())
+            tester.parse("-1").isGood(2, opUnMinus(1))
+            tester.parse("1 + 2").isGood(3, 1 opAdd 2)
+            tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.toLit()))
             tester.parse("++a").isGood(2, Assignment.PreIncrement("a"))
-            tester.parse("a + b").isGood(3, Operator.Add("a".variable, "b".variable))
+            tester.parse("1 + 2").isGood(3, 1 opAdd 2)
         }
         
         @Test
@@ -45,13 +42,13 @@ class TestParseExpressions
     @Nested
     inner class TestParserBoolExpression
     {
-        private val tester = PatternTester { ParserBoolExpression }
+        private val tester = ParserTester { ParserBoolExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("true").isGood(1, true.value)
-            tester.parse("false").isGood(1, false.value)
+            tester.parse("true").isGood(1, true.toLit())
+            tester.parse("false").isGood(1, false.toLit())
         }
         
         @Test
@@ -66,12 +63,12 @@ class TestParseExpressions
     @Nested
     inner class TestParserRealExpression
     {
-        private val tester = PatternTester { ParserRealExpression }
+        private val tester = ParserTester { ParserRealExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("42").isGood(1, 42.value)
+            tester.parse("42").isGood(1, 42.toLit())
         }
         
         @Test
@@ -85,12 +82,12 @@ class TestParseExpressions
     @Nested
     inner class TestParserTextExpression
     {
-        private val tester = PatternTester { ParserTextExpression }
+        private val tester = ParserTester { ParserTextExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("\"whatever\"").isGood(1, "whatever".value)
+            tester.parse("\"whatever\"").isGood(1, "whatever".toLit())
         }
         
         @Test
@@ -104,12 +101,12 @@ class TestParseExpressions
     @Nested
     inner class TestParserVariableExpression
     {
-        private val tester = PatternTester { ParserVariableExpression }
+        private val tester = ParserTester { ParserVariableExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("foo").isGood(1, "foo".variable)
+            tester.parse("foo").isGood(1, "foo".toVar())
         }
         
         @Test
@@ -123,16 +120,16 @@ class TestParseExpressions
     @Nested
     inner class TestParserFunctionExpression
     {
-        private val tester = PatternTester { ParserFunctionExpression }
+        private val tester = ParserTester { ParserFunctionExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("f()").isGood(3, "f".function)
-            tester.parse("f(1)").isGood(4, Access.Function("f", listOf(1.parameter)))
-            tester.parse("f(1, 2)").isGood(6, Access.Function("f", listOf(1.parameter, 2.parameter)))
-            tester.parse("f(1, 2, )").isGood(7, Access.Function("f", listOf(1.parameter, 2.parameter)))
-            tester.parse("f(foo = 1)").isGood(6, Access.Function("f", listOf(Parameter("foo", 1.value))))
+            tester.parse("f()").isGood(3, "f".toFun())
+            tester.parse("f(1)").isGood(4, "f".toFun(1.toPar()))
+            tester.parse("f(1, 2)").isGood(6, "f".toFun(1.toPar(), 2.toPar()))
+            tester.parse("f(1, 2, )").isGood(7, "f".toFun(1.toPar(), 2.toPar()))
+            tester.parse("f(foo = 1)").isGood(6, "f".toFun(1.toPar("foo")))
         }
         
         @Test
@@ -146,12 +143,12 @@ class TestParseExpressions
     @Nested
     inner class TestParserParenthesisExpression
     {
-        private val tester = PatternTester { ParserParenthesisExpression }
+        private val tester = ParserTester { ParserParenthesisExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("(1)").isGood(3, 1.value)
+            tester.parse("(1)").isGood(3, 1.toLit())
         }
         
         @Test
@@ -168,14 +165,14 @@ class TestParseExpressions
     @Nested
     inner class TestParserPrefixOperatorExpression
     {
-        private val tester = PatternTester { ParserPrefixOperatorExpression }
+        private val tester = ParserTester { ParserPrefixOperatorExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("!1").isGood(2, Operator.Not(1.value))
-            tester.parse("+1").isGood(2, Operator.UnaryPlus(1.value))
-            tester.parse("-1").isGood(2, Operator.UnaryMinus(1.value))
+            tester.parse("!1").isGood(2, opNot(1))
+            tester.parse("+1").isGood(2, opUnPlus(1))
+            tester.parse("-1").isGood(2, opUnMinus(1))
         }
         
         @Test
@@ -190,38 +187,38 @@ class TestParseExpressions
     @Nested
     inner class TestParserInfixOperatorExpression
     {
-        private val tester = PatternTester { ParserInfixOperatorExpression }
+        private val tester = ParserTester { ParserInfixOperatorExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
             // Comparison
-            tester.parse("1 == 2").isGood(3, Operator.Equal(1.value, 2.value))
-            tester.parse("1 != 2").isGood(3, Operator.NotEqual(1.value, 2.value))
-            tester.parse("1 < 2").isGood(3, Operator.Less(1.value, 2.value))
-            tester.parse("1 <= 2").isGood(3, Operator.LessEqual(1.value, 2.value))
-            tester.parse("1 > 2").isGood(3, Operator.Greater(1.value, 2.value))
-            tester.parse("1 >= 2").isGood(3, Operator.GreaterEqual(1.value, 2.value))
-            tester.parse("1 <=> 2").isGood(3, Operator.ThreeWay(1.value, 2.value))
+            tester.parse("1 == 2").isGood(3, 1 opEq 2)
+            tester.parse("1 != 2").isGood(3, 1 opNe 2)
+            tester.parse("1 < 2").isGood(3, 1 opLt 2)
+            tester.parse("1 <= 2").isGood(3, 1 opLe 2)
+            tester.parse("1 > 2").isGood(3, 1 opGt 2)
+            tester.parse("1 >= 2").isGood(3, 1 opGe 2)
+            tester.parse("1 <=> 2").isGood(3, 1 opTw 2)
             
             // Logical
-            tester.parse("1 && 2").isGood(3, Operator.And(1.value, 2.value))
-            tester.parse("1 || 2").isGood(3, Operator.Or(1.value, 2.value))
-            tester.parse("1 ^^ 2").isGood(3, Operator.Xor(1.value, 2.value))
+            tester.parse("1 && 2").isGood(3, 1 opAnd 2)
+            tester.parse("1 || 2").isGood(3, 1 opOr 2)
+            tester.parse("1 ^^ 2").isGood(3, 1 opXor 2)
             
             // Arithmetic
-            tester.parse("1 + 2").isGood(3, Operator.Add(1.value, 2.value))
-            tester.parse("1 - 2").isGood(3, Operator.Subtract(1.value, 2.value))
-            tester.parse("1 * 2").isGood(3, Operator.Multiply(1.value, 2.value))
-            tester.parse("1 / 2").isGood(3, Operator.Divide(1.value, 2.value))
-            tester.parse("1 % 2").isGood(3, Operator.Modulo(1.value, 2.value))
+            tester.parse("1 + 2").isGood(3, 1 opAdd 2)
+            tester.parse("1 - 2").isGood(3, 1 opSub 2)
+            tester.parse("1 * 2").isGood(3, 1 opMul 2)
+            tester.parse("1 / 2").isGood(3, 1 opDiv 2)
+            tester.parse("1 % 2").isGood(3, 1 opMod 2)
         }
         
         @Test
         fun `Given token precedence, when parsing, then correct precedence`()
         {
-            tester.parse("1 + 2 * 3").isGood(5, Operator.Add(1.value, Operator.Multiply(2.value, 3.value)))
-            tester.parse("1 * 2 + 3").isGood(5, Operator.Add(Operator.Multiply(1.value, 2.value), 3.value))
+            tester.parse("1 + 2 * 3").isGood(5, 1 opAdd (2 opMul 3))
+            tester.parse("1 * 2 + 3").isGood(5, (1 opMul 2) opAdd 3)
         }
         
         @Test
@@ -237,17 +234,17 @@ class TestParseExpressions
     @Nested
     inner class TestParserAssignExpression
     {
-        private val tester = PatternTester { ParserAssignExpression }
+        private val tester = ParserTester { ParserAssignExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()
         {
-            tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.value))
-            tester.parse("a += 1").isGood(3, Assignment.AssignAdd("a", 1.value))
-            tester.parse("a -= 1").isGood(3, Assignment.AssignSubtract("a", 1.value))
-            tester.parse("a *= 1").isGood(3, Assignment.AssignMultiply("a", 1.value))
-            tester.parse("a /= 1").isGood(3, Assignment.AssignDivide("a", 1.value))
-            tester.parse("a %= 1").isGood(3, Assignment.AssignModulo("a", 1.value))
+            tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.toLit()))
+            tester.parse("a += 1").isGood(3, Assignment.AssignAdd("a", 1.toLit()))
+            tester.parse("a -= 1").isGood(3, Assignment.AssignSubtract("a", 1.toLit()))
+            tester.parse("a *= 1").isGood(3, Assignment.AssignMultiply("a", 1.toLit()))
+            tester.parse("a /= 1").isGood(3, Assignment.AssignDivide("a", 1.toLit()))
+            tester.parse("a %= 1").isGood(3, Assignment.AssignModulo("a", 1.toLit()))
         }
         
         @Test
@@ -263,7 +260,7 @@ class TestParseExpressions
     @Nested
     inner class TestParserIncrementExpression
     {
-        private val tester = PatternTester { ParserIncrementExpression }
+        private val tester = ParserTester { ParserIncrementExpression }
         
         @Test
         fun `Given valid token, when parsing, then correctly parsed`()

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestTokens.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestTokens.kt
@@ -1,5 +1,7 @@
 package com.github.derg.transpiler.parser.patterns
 
+import com.github.derg.transpiler.lexer.Keyword.Type.IF
+import com.github.derg.transpiler.lexer.Keyword.Type.WHILE
 import com.github.derg.transpiler.lexer.Operator.Type.MINUS
 import com.github.derg.transpiler.lexer.Operator.Type.MULTIPLY
 import com.github.derg.transpiler.lexer.Structure.Type.COMMA
@@ -25,6 +27,28 @@ class TestParserIdentifier
         tester.parse("false").isBad { NotIdentifier(it[0]) }
     }
 }
+
+class TestParserKeyword
+{
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        val tester = ParserTester { ParserKeyword() }
+        
+        tester.parse("while").isGood(1, WHILE)
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        val tester = ParserTester { ParserKeyword(WHILE) }
+        
+        tester.parse("").isBad { End }
+        tester.parse("if").isBad { WrongKeyword(setOf(WHILE), IF) }
+        tester.parse("42").isBad { NotKeyword(it[0]) }
+    }
+}
+
 
 class TestParserOperator
 {

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestTokens.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestTokens.kt
@@ -5,12 +5,12 @@ import com.github.derg.transpiler.lexer.Operator.Type.MULTIPLY
 import com.github.derg.transpiler.lexer.Structure.Type.COMMA
 import com.github.derg.transpiler.lexer.Structure.Type.OPEN_BRACKET
 import com.github.derg.transpiler.parser.ParseError.*
-import com.github.derg.transpiler.parser.PatternTester
+import com.github.derg.transpiler.parser.ParserTester
 import org.junit.jupiter.api.Test
 
 class TestParserIdentifier
 {
-    private val tester = PatternTester { ParserIdentifier }
+    private val tester = ParserTester { ParserIdentifier }
     
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
@@ -31,7 +31,7 @@ class TestParserOperator
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
-        val tester = PatternTester { ParserOperator() }
+        val tester = ParserTester { ParserOperator() }
         
         tester.parse("*").isGood(1, MULTIPLY)
     }
@@ -39,7 +39,7 @@ class TestParserOperator
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        val tester = PatternTester { ParserOperator(MINUS) }
+        val tester = ParserTester { ParserOperator(MINUS) }
         
         tester.parse("").isBad { End }
         tester.parse("*").isBad { WrongOperator(setOf(MINUS), MULTIPLY) }
@@ -52,7 +52,7 @@ class TestParserStructure
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
     {
-        val tester = PatternTester { ParserStructure() }
+        val tester = ParserTester { ParserStructure() }
         
         tester.parse(",").isGood(1, COMMA)
     }
@@ -60,7 +60,7 @@ class TestParserStructure
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        val tester = PatternTester { ParserStructure(COMMA) }
+        val tester = ParserTester { ParserStructure(COMMA) }
         
         tester.parse("").isBad { End }
         tester.parse("[").isBad { WrongStructure(setOf(COMMA), OPEN_BRACKET) }


### PR DESCRIPTION
Closes #14.

Re-implements the parsing of variable definitions, as this was accidentally removed in a previous cleanup refactor session. With this change, it is possible to define variables again.