### PR TITLE
Remove pre- and postfix incrementing and decrementing

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
@@ -65,30 +65,6 @@ sealed class Access : Expression()
  */
 sealed class Assignment : Expression()
 {
-    // INCREMENTING AND DECREMENTING ASSIGNMENTS
-    
-    /**
-     * Performs an increment on the variable with the given [name], returning the value *after* incrementing.
-     */
-    data class PreIncrement(val name: Name) : Assignment()
-    
-    /**
-     * Performs a decrement on the variable with the given [name], returning the value *after* decrementing.
-     */
-    data class PreDecrement(val name: Name) : Assignment()
-    
-    /**
-     * Performs an increment on the variable with the given [name], returning the value *before* incrementing.
-     */
-    data class PostIncrement(val name: Name) : Assignment()
-    
-    /**
-     * Performs a decrement on the variable with the given [name], returning the value *before* decrementing.
-     */
-    data class PostDecrement(val name: Name) : Assignment()
-    
-    // ASSIGNMENT ASSIGNMENTS
-    
     /**
      * Assigns the given [expression] to [name], returning the new value of [name].
      */

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Expressions.kt
@@ -26,7 +26,6 @@ private val EXPRESSIONS = arrayOf(
     ParserPrefixOperatorExpression,
     ParserParenthesisExpression,
     ParserAssignExpression,
-    ParserIncrementExpression,
 )
 
 /**
@@ -273,34 +272,6 @@ object ParserAssignExpression : Parser<Expression>
         ASSIGN_DIVIDE   -> Assignment.AssignDivide(name, expression)
         ASSIGN_MODULO   -> Assignment.AssignModulo(name, expression)
         else            -> throw IllegalStateException("Illegal operator $operator when parsing assignment")
-    }
-}
-
-/**
- * Parses an expression where a variable is either incremented or decremented as a pre- or postfix operator from the
- * context, if possible. The grammar assigns a higher priority to the prefix operator, effectively preventing issues
- * where both the pre- and postfix operators are specified.
- */
-object ParserIncrementExpression : Parser<Expression>
-{
-    private val pattern = ParserAnyOf(
-        ParserSequence(ParserOperator(INCREMENT, DECREMENT), ParserIdentifier),
-        ParserSequence(ParserIdentifier, ParserOperator(INCREMENT, DECREMENT)),
-    )
-    
-    override fun parse(context: Context): Result<Expression, ParseError>
-    {
-        val result = pattern.parse(context).valueOr { return failureOf(it) }
-        val name = result[0] as? Name ?: result[1] as Name
-        val operator = result[0] as? OperatorType ?: result[1] as OperatorType
-        return convert(name, operator, result[0] is OperatorType).toSuccess()
-    }
-    
-    private fun convert(name: Name, operator: OperatorType, isPrefix: Boolean): Expression = when (operator)
-    {
-        INCREMENT -> if (isPrefix) Assignment.PreIncrement(name) else Assignment.PostIncrement(name)
-        DECREMENT -> if (isPrefix) Assignment.PreDecrement(name) else Assignment.PostDecrement(name)
-        else      -> throw IllegalStateException("Illegal operator $operator when parsing assignment")
     }
 }
 

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
@@ -27,7 +27,6 @@ class TestParseExpressions
             tester.parse("-1").isGood(2, opUnMinus(1))
             tester.parse("1 + 2").isGood(3, 1 opAdd 2)
             tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.toLit()))
-            tester.parse("++a").isGood(2, Assignment.PreIncrement("a"))
             tester.parse("1 + 2").isGood(3, 1 opAdd 2)
         }
         
@@ -254,29 +253,6 @@ class TestParseExpressions
             tester.parse("foo").isBad { End }
             tester.parse("foo = ").isBad { End }
             tester.parse("if").isBad { NotIdentifier(it[0]) }
-        }
-    }
-    
-    @Nested
-    inner class TestParserIncrementExpression
-    {
-        private val tester = ParserTester { ParserIncrementExpression }
-        
-        @Test
-        fun `Given valid token, when parsing, then correctly parsed`()
-        {
-            tester.parse("++a").isGood(2, Assignment.PreIncrement("a"))
-            tester.parse("--a").isGood(2, Assignment.PreDecrement("a"))
-            tester.parse("a++").isGood(2, Assignment.PostIncrement("a"))
-            tester.parse("a--").isGood(2, Assignment.PostDecrement("a"))
-        }
-        
-        @Test
-        fun `Given invalid token, when parsing, then correct error`()
-        {
-            tester.parse("").isBad { End }
-            tester.parse("++").isBad { End }
-            tester.parse("if").isBad { NotOperator(it[0]) }
         }
     }
 }


### PR DESCRIPTION
Closes #27.

In order to simplify parsing of source code, and to remove another point of confusion for programmers, the pre- and postfix increment and decrement operators should be removed. These operators do not serve a value high enough to warrant further existence, and thus can be culled.