### PR TITLE
Move assignment out from expressions into a standalone statement instead

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Assignments.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Assignments.kt
@@ -1,0 +1,41 @@
+package com.github.derg.transpiler.ast
+
+import com.github.derg.transpiler.core.Name
+
+/**
+ * Expressions may be turned into l-values by being stored in a variable of any kind. In doing so, the r-value
+ * expression may be referenced or otherwise accessed again at any later time. All statements which alters the value of
+ * a variable is considered to be an assignment.
+ */
+sealed class Assignment : Expression()
+{
+    /**
+     * Assigns the given [expression] to [name], returning the new value of [name].
+     */
+    data class Assign(val name: Name, val expression: Expression) : Assignment()
+    
+    /**
+     * Adds the given [expression] to [name], returning the new value of [name].
+     */
+    data class AssignAdd(val name: Name, val expression: Expression) : Assignment()
+    
+    /**
+     * Subtracts the given [expression] from [name], returning the new value of [name].
+     */
+    data class AssignSubtract(val name: Name, val expression: Expression) : Assignment()
+    
+    /**
+     * Multiplies [name] with the given [expression], returning the new value of [name].
+     */
+    data class AssignMultiply(val name: Name, val expression: Expression) : Assignment()
+    
+    /**
+     * Divides [name] by the given [expression], returning the new value of [name].
+     */
+    data class AssignDivide(val name: Name, val expression: Expression) : Assignment()
+    
+    /**
+     * Assigns the modulo of [name] with the given [expression], returning the new value of [name].
+     */
+    data class AssignModulo(val name: Name, val expression: Expression) : Assignment()
+}

--- a/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
@@ -59,44 +59,6 @@ sealed class Access : Expression()
 }
 
 /**
- * Expressions may be turned into l-values by being stored in a variable of any kind. In doing so, the r-value
- * expression may be referenced or otherwise accessed again at any later time. All statements which alters the value of
- * a variable is considered to be an assignment.
- */
-sealed class Assignment : Expression()
-{
-    /**
-     * Assigns the given [expression] to [name], returning the new value of [name].
-     */
-    data class Assign(val name: Name, val expression: Expression) : Assignment()
-    
-    /**
-     * Adds the given [expression] to [name], returning the new value of [name].
-     */
-    data class AssignAdd(val name: Name, val expression: Expression) : Assignment()
-    
-    /**
-     * Subtracts the given [expression] from [name], returning the new value of [name].
-     */
-    data class AssignSubtract(val name: Name, val expression: Expression) : Assignment()
-    
-    /**
-     * Multiplies [name] with the given [expression], returning the new value of [name].
-     */
-    data class AssignMultiply(val name: Name, val expression: Expression) : Assignment()
-    
-    /**
-     * Divides [name] by the given [expression], returning the new value of [name].
-     */
-    data class AssignDivide(val name: Name, val expression: Expression) : Assignment()
-    
-    /**
-     * Assigns the modulo of [name] with the given [expression], returning the new value of [name].
-     */
-    data class AssignModulo(val name: Name, val expression: Expression) : Assignment()
-}
-
-/**
  * Any two expressions may be combined with an operator to form a new value. The operator determines which operation
  * will be performed on the expressions participating in the operation. Certain operations require only one expression,
  * some require two.

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Expressions.kt
@@ -25,7 +25,6 @@ private val EXPRESSIONS = arrayOf(
     ParserFunctionExpression,
     ParserPrefixOperatorExpression,
     ParserParenthesisExpression,
-    ParserAssignExpression,
 )
 
 /**
@@ -243,35 +242,6 @@ object ParserInfixOperatorExpression : Parser<Expression>
         THREE_WAY     -> Operator.ThreeWay(lhs, rhs)
         XOR           -> Operator.Xor(lhs, rhs)
         else          -> throw IllegalStateException("Illegal operator $operator when parsing prefix operator")
-    }
-}
-
-/**
- * Parses an expression where a variable is assigned any arbitrary expression from the context, if possible. The grammar
- * does not forbid the assignment expression for occurring any location an ordinary expression can appear.
- */
-object ParserAssignExpression : Parser<Expression>
-{
-    private val pattern = ParserSequence(
-        ParserIdentifier,
-        ParserOperator(ASSIGN, ASSIGN_PLUS, ASSIGN_MINUS, ASSIGN_MULTIPLY, ASSIGN_DIVIDE, ASSIGN_MODULO),
-        ParserExpression,
-    )
-    
-    override fun parse(context: Context): Result<Expression, ParseError>
-    {
-        return pattern.parse(context).mapValue { convert(it[0] as Name, it[1] as OperatorType, it[2] as Expression) }
-    }
-    
-    private fun convert(name: Name, operator: OperatorType, expression: Expression): Expression = when (operator)
-    {
-        ASSIGN          -> Assignment.Assign(name, expression)
-        ASSIGN_PLUS     -> Assignment.AssignAdd(name, expression)
-        ASSIGN_MINUS    -> Assignment.AssignSubtract(name, expression)
-        ASSIGN_MULTIPLY -> Assignment.AssignMultiply(name, expression)
-        ASSIGN_DIVIDE   -> Assignment.AssignDivide(name, expression)
-        ASSIGN_MODULO   -> Assignment.AssignModulo(name, expression)
-        else            -> throw IllegalStateException("Illegal operator $operator when parsing assignment")
     }
 }
 

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Statements.kt
@@ -1,0 +1,45 @@
+package com.github.derg.transpiler.parser.patterns
+
+import com.github.derg.transpiler.ast.Assignment
+import com.github.derg.transpiler.ast.Expression
+import com.github.derg.transpiler.core.Name
+import com.github.derg.transpiler.lexer.Operator
+import com.github.derg.transpiler.parser.Context
+import com.github.derg.transpiler.parser.ParseError
+import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.util.Result
+import com.github.derg.transpiler.util.mapValue
+
+/**
+ * Parses an expression where a variable is assigned any arbitrary expression from the context, if possible. The grammar
+ * does not forbid the assignment expression for occurring any location an ordinary expression can appear.
+ */
+object ParserAssignment : Parser<Expression>
+{
+    private val pattern = ParserSequence(
+        ParserIdentifier,
+        ParserOperator(Operator.Type.ASSIGN,
+            Operator.Type.ASSIGN_PLUS,
+            Operator.Type.ASSIGN_MINUS,
+            Operator.Type.ASSIGN_MULTIPLY,
+            Operator.Type.ASSIGN_DIVIDE,
+            Operator.Type.ASSIGN_MODULO),
+        ParserExpression,
+    )
+    
+    override fun parse(context: Context): Result<Expression, ParseError>
+    {
+        return pattern.parse(context).mapValue { convert(it[0] as Name, it[1] as Operator.Type, it[2] as Expression) }
+    }
+    
+    private fun convert(name: Name, operator: Operator.Type, expression: Expression): Expression = when (operator)
+    {
+        Operator.Type.ASSIGN          -> Assignment.Assign(name, expression)
+        Operator.Type.ASSIGN_PLUS     -> Assignment.AssignAdd(name, expression)
+        Operator.Type.ASSIGN_MINUS    -> Assignment.AssignSubtract(name, expression)
+        Operator.Type.ASSIGN_MULTIPLY -> Assignment.AssignMultiply(name, expression)
+        Operator.Type.ASSIGN_DIVIDE   -> Assignment.AssignDivide(name, expression)
+        Operator.Type.ASSIGN_MODULO   -> Assignment.AssignModulo(name, expression)
+        else                          -> throw IllegalStateException("Illegal operator $operator when parsing assignment")
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
@@ -1,6 +1,5 @@
 package com.github.derg.transpiler.parser.patterns
 
-import com.github.derg.transpiler.ast.Assignment
 import com.github.derg.transpiler.lexer.Structure.Type.CLOSE_PARENTHESIS
 import com.github.derg.transpiler.lexer.Structure.Type.OPEN_PARENTHESIS
 import com.github.derg.transpiler.parser.*
@@ -26,7 +25,6 @@ class TestParseExpressions
             tester.parse("f()").isGood(3, "f".toFun())
             tester.parse("-1").isGood(2, opUnMinus(1))
             tester.parse("1 + 2").isGood(3, 1 opAdd 2)
-            tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.toLit()))
             tester.parse("1 + 2").isGood(3, 1 opAdd 2)
         }
         
@@ -227,32 +225,6 @@ class TestParseExpressions
             tester.parse("2").isBad { End }
             tester.parse("3 +").isBad { End }
             tester.parse("if").isBad { NotExpression(it[0]) }
-        }
-    }
-    
-    @Nested
-    inner class TestParserAssignExpression
-    {
-        private val tester = ParserTester { ParserAssignExpression }
-        
-        @Test
-        fun `Given valid token, when parsing, then correctly parsed`()
-        {
-            tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.toLit()))
-            tester.parse("a += 1").isGood(3, Assignment.AssignAdd("a", 1.toLit()))
-            tester.parse("a -= 1").isGood(3, Assignment.AssignSubtract("a", 1.toLit()))
-            tester.parse("a *= 1").isGood(3, Assignment.AssignMultiply("a", 1.toLit()))
-            tester.parse("a /= 1").isGood(3, Assignment.AssignDivide("a", 1.toLit()))
-            tester.parse("a %= 1").isGood(3, Assignment.AssignModulo("a", 1.toLit()))
-        }
-        
-        @Test
-        fun `Given invalid token, when parsing, then correct error`()
-        {
-            tester.parse("").isBad { End }
-            tester.parse("foo").isBad { End }
-            tester.parse("foo = ").isBad { End }
-            tester.parse("if").isBad { NotIdentifier(it[0]) }
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
@@ -1,0 +1,32 @@
+package com.github.derg.transpiler.parser.patterns
+
+import com.github.derg.transpiler.ast.Assignment
+import com.github.derg.transpiler.parser.ParseError
+import com.github.derg.transpiler.parser.ParserTester
+import com.github.derg.transpiler.parser.toLit
+import org.junit.jupiter.api.Test
+
+class TestParserAssignment
+{
+    private val tester = ParserTester { ParserAssignment }
+    
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        tester.parse("a = 1").isGood(3, Assignment.Assign("a", 1.toLit()))
+        tester.parse("a += 1").isGood(3, Assignment.AssignAdd("a", 1.toLit()))
+        tester.parse("a -= 1").isGood(3, Assignment.AssignSubtract("a", 1.toLit()))
+        tester.parse("a *= 1").isGood(3, Assignment.AssignMultiply("a", 1.toLit()))
+        tester.parse("a /= 1").isGood(3, Assignment.AssignDivide("a", 1.toLit()))
+        tester.parse("a %= 1").isGood(3, Assignment.AssignModulo("a", 1.toLit()))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.End }
+        tester.parse("foo").isBad { ParseError.End }
+        tester.parse("foo = ").isBad { ParseError.End }
+        tester.parse("if").isBad { ParseError.NotIdentifier(it[0]) }
+    }
+}


### PR DESCRIPTION
Closes #28.

Refactors the assignment of variables to a dedicated statement instead of degrading down to an expression. This has the impact that assignments cannot return any value, since it is not an expression.