### PR TITLE
Implement parsing of functions

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Definitions.kt
@@ -67,3 +67,29 @@ data class Variable(
     val visibility: Visibility,
     val mutability: Mutability,
 ) : Definition()
+
+/**
+ * Functions are smaller subroutines of a program which can perform a specialized workload. Every function may return a
+ * [valueType], or raise an [errorType]. Functions accept any number of [parameters]. The value and error types are not
+ * required to be specified.
+ *
+ * @param visibility The visibility of the variable, to whom it is possible to access.
+ */
+data class Function(
+    val name: Name,
+    val valueType: Name?,
+    val errorType: Name?,
+    val parameters: List<FunctionParameter>,
+    val visibility: Visibility,
+)
+
+/**
+ * Every function may have any number of parameters, each with their own [name], optional [type] information and
+ * optional default [value]. Parameters must contain some degree of [mutability] specifier.
+ */
+data class FunctionParameter(
+    val name: Name,
+    val type: Name?,
+    val value: Expression?,
+    val mutability: Mutability,
+)

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
@@ -1,10 +1,7 @@
 package com.github.derg.transpiler.parser.patterns
 
-import com.github.derg.transpiler.ast.Expression
-import com.github.derg.transpiler.ast.Mutability
-import com.github.derg.transpiler.ast.Variable
-import com.github.derg.transpiler.ast.Visibility
-import com.github.derg.transpiler.core.Name
+import com.github.derg.transpiler.ast.*
+import com.github.derg.transpiler.ast.Function
 import com.github.derg.transpiler.lexer.SymbolType
 import com.github.derg.transpiler.lexer.Token
 import com.github.derg.transpiler.parser.ParseError
@@ -39,24 +36,86 @@ private fun mutabilityOf(symbol: SymbolType): Mutability = when (symbol)
 class ParserVariableDefinition : Parser<Variable>
 {
     private val parser = ParserSequence(
-        "properties" to ParserAllOf(
-            "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
-            "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
-        ),
+        "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
+        "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
         "name" to ParserName(),
         "op" to ParserSymbol(SymbolType.ASSIGN),
-        "rhs" to ParserExpression(),
+        "value" to ParserExpression(),
     )
     
     override fun produce(): Variable?
     {
         val values = parser.produce()
-        val properties = values.produce<Parsers>("properties") ?: return null
-        val visibility = visibilityOf(properties.produce("visibility"))
-        val mutability = mutabilityOf(properties.produce("mutability") ?: return null)
-        val name = values.produce<Name>("name") ?: return null
-        val rhs = values.produce<Expression>("rhs") ?: return null
-        return Variable(name = name, type = null, value = rhs, visibility = visibility, mutability = mutability)
+        return Variable(
+            name = values.produce("name") ?: return null,
+            type = null,
+            value = values.produce("value") ?: return null,
+            visibility = visibilityOf(values.produce("visibility")),
+            mutability = mutabilityOf(values.produce("mutability") ?: return null),
+        )
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
+    override fun reset() = parser.reset()
+}
+
+/**
+ * Parses a function definition from the provided token.
+ */
+class ParserFunctionDefinition : Parser<Function>
+{
+    private val parser = ParserSequence(
+        "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
+        "fun" to ParserSymbol(SymbolType.FUN),
+        "name" to ParserName(),
+        "open_parenthesis" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
+        "parameters" to ParserRepeating(ParserFunctionParameterDefinition(), ParserSymbol(SymbolType.COMMA)),
+        "close_parenthesis" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
+        "error" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
+        "value" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ARROW), "type" to ParserName())),
+        "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
+        "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
+    )
+    
+    override fun produce(): Function?
+    {
+        val values = parser.produce()
+        return Function(
+            name = values.produce("name") ?: return null,
+            valueType = values.produce<Parsers>("value")?.produce("type"),
+            errorType = values.produce<Parsers>("error")?.produce("type"),
+            parameters = values.produce("parameters") ?: emptyList(),
+            visibility = visibilityOf(values.produce("visibility")),
+        )
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
+    override fun reset() = parser.reset()
+}
+
+/**
+ * Parses a function parameter definition from the provided token.
+ */
+private class ParserFunctionParameterDefinition : Parser<FunctionParameter>
+{
+    private val parser = ParserSequence(
+        "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
+        "name" to ParserName(),
+        "type" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
+        "val" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ASSIGN), "val" to ParserExpression())),
+    )
+    
+    override fun produce(): FunctionParameter?
+    {
+        val values = parser.produce()
+        return FunctionParameter(
+            name = values.produce("name") ?: return null,
+            type = values.produce<Parsers>("type")?.produce("type"),
+            value = values.produce<Parsers>("bal")?.produce("val"),
+            mutability = mutabilityOf(values.produce("mutability") ?: return null),
+        )
     }
     
     override fun skipable(): Boolean = false

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -1,6 +1,7 @@
 package com.github.derg.transpiler.parser
 
 import com.github.derg.transpiler.ast.*
+import com.github.derg.transpiler.ast.Function
 import com.github.derg.transpiler.core.Name
 import com.github.derg.transpiler.lexer.EndOfFile
 import com.github.derg.transpiler.lexer.Token
@@ -76,6 +77,38 @@ fun varOf(
     type = type,
     value = value.toExp(),
     visibility = vis,
+    mutability = mut,
+)
+
+/**
+ * Generates function definition from the provided input parameters.
+ */
+fun funOf(
+    name: Name,
+    valType: Name? = null,
+    errType: Name? = null,
+    vis: Visibility = Visibility.PRIVATE,
+    params: List<FunctionParameter> = emptyList(),
+) = Function(
+    name = name,
+    valueType = valType,
+    errorType = errType,
+    parameters = params,
+    visibility = vis,
+)
+
+/**
+ * Generates function parameter definition from the provided input parameters.
+ */
+fun parOf(
+    name: Name,
+    type: Name? = null,
+    value: Any? = null,
+    mut: Mutability = Mutability.VALUE,
+) = FunctionParameter(
+    name = name,
+    type = type,
+    value = value?.toExp(),
     mutability = mut,
 )
 

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
@@ -3,12 +3,18 @@ package com.github.derg.transpiler.parser.patterns
 import com.github.derg.transpiler.ast.Mutability
 import com.github.derg.transpiler.ast.Visibility
 import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.Tester
-import com.github.derg.transpiler.parser.varOf
+import com.github.derg.transpiler.parser.*
 import org.junit.jupiter.api.Test
 
-class TestParseVariableDefinition
+/**
+ * Determines whether the current token stream is parsed correctly. The expectation is that there will be [preOkCount]
+ * number of tokens resulting in [ParseOk.Complete], followed by [wipCount] [ParseOk.Incomplete], then followed by
+ * [postOkCount] [ParseOk.Complete] again, before finally resulting in [ParseOk.Finished].
+ */
+private fun <Type> Tester<Type>.isChain(wipCount: Int = 0, postOkCount: Int = 0): Tester<Type> =
+    isWip(wipCount).isOk(postOkCount).isDone()
+
+class TestParserVariableDefinition
 {
     private val tester = Tester { ParserVariableDefinition() }
     
@@ -16,13 +22,13 @@ class TestParseVariableDefinition
     fun `Given valid token, when parsing, then correctly parsed`()
     {
         // Mutability must be correctly parsed
-        tester.parse("val foo = 0").isWip(3).isOk(1).isDone().isValue(varOf("foo", 0, mut = Mutability.VALUE))
-        tester.parse("var foo = 0").isWip(3).isOk(1).isDone().isValue(varOf("foo", 0, mut = Mutability.VARYING))
-        tester.parse("mut foo = 0").isWip(3).isOk(1).isDone().isValue(varOf("foo", 0, mut = Mutability.MUTABLE))
+        tester.parse("val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.VALUE))
+        tester.parse("var foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.VARYING))
+        tester.parse("mut foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.MUTABLE))
         
         // Visibility must be correctly parsed
-        tester.parse("pub val foo = 0").isWip(4).isOk(1).isDone().isValue(varOf("foo", 0, vis = Visibility.PUBLIC))
-        tester.parse("    val foo = 0").isWip(3).isOk(1).isDone().isValue(varOf("foo", 0, vis = Visibility.PRIVATE))
+        tester.parse("pub val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PUBLIC))
+        tester.parse("    val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, vis = Visibility.PRIVATE))
     }
     
     @Test
@@ -31,5 +37,48 @@ class TestParseVariableDefinition
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("val").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("val foo =").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
+    }
+}
+
+class TestParserFunctionDefinition
+{
+    private val tester = Tester { ParserFunctionDefinition() }
+    
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        // Basic structure must be correctly parsed
+        tester.parse("fun foo() {}").isChain(5, 1).isValue(funOf("foo"))
+        tester.parse("fun foo() -> Foo {}").isChain(7, 1).isValue(funOf("foo", valType = "Foo"))
+        tester.parse("fun foo(): Foo {}").isChain(7, 1).isValue(funOf("foo", errType = "Foo"))
+        tester.parse("fun foo(): Foo -> Bar {}").isChain(9, 1).isValue(funOf("foo", valType = "Bar", errType = "Foo"))
+        
+        // Parameters must be correctly parsed
+        tester.parse("fun foo(val a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", mut = Mutability.VALUE))))
+        tester.parse("fun foo(var a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", mut = Mutability.VARYING))))
+        tester.parse("fun foo(mut a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", mut = Mutability.MUTABLE))))
+        
+        val params = listOf(
+            parOf("a", type = "Foo", mut = Mutability.VALUE),
+            parOf("b", type = "Bar", mut = Mutability.VALUE),
+        )
+        
+        tester.parse("fun foo(val a: Foo, val b: Bar) {}").isChain(14, 1)
+            .isValue(funOf("foo", params = params))
+        
+        // Visibility must be correctly parsed
+        tester.parse("pub fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PUBLIC))
+        tester.parse("    fun foo() {}").isChain(5, 1).isValue(funOf("foo", vis = Visibility.PRIVATE))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("fun").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("fun foo(").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
     }
 }


### PR DESCRIPTION
Closes #19.

This merge request introduces parsing of functions, although leaves the body of functions as future work. The functions may have an arbitrary number of parameters, an an optional return type, plus an optional error type. Certain properties of the function may be specified as well, although the structure remains limited as of now.