### PR TITLE
36 implement catch and raise operators

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
@@ -179,4 +179,18 @@ sealed class Operator : Expression()
      * Performs a modulo operation between the [lhs] and [rhs] expressions.
      */
     data class Modulo(val lhs: Expression, val rhs: Expression) : Operator()
+    
+    // ERROR OPERATORS
+    
+    /**
+     * Catches any errors which are raised in the [lhs] expression, replacing errors with the [rhs] expression. In
+     * essence, this operator allows errors to be caught and replaced with a default value in their place.
+     */
+    data class Catch(val lhs: Expression, val rhs: Expression) : Operator()
+    
+    /**
+     * Catches any errors which are raised in the [lhs] expression. This operator transforms the error into another
+     * error, determined by the error type of the function.
+     */
+    data class Raise(val lhs: Expression, val rhs: Expression) : Operator()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
@@ -72,16 +72,21 @@ sealed class Operator : Expression()
     // UNARY OPERATORS
     
     /**
-     * Represents the positive value of [expression]. In almost all cases, this operation is a no-op and should not be
-     * utilized in software. It exists primarily to support the `+1` syntax, for symmetrical purposes (as `-1` is legal
-     * syntax).
+     * Represents the positive value of [expression]. In all cases, this operation is a no-op. It exists to support the
+     * `+1` syntax, for symmetrical purposes (as `-1` is legal syntax).
      */
-    data class UnaryPlus(val expression: Expression) : Operator()
+    data class Plus(val expression: Expression) : Operator()
     
     /**
      * Represents the negative value of [expression].
      */
-    data class UnaryMinus(val expression: Expression) : Operator()
+    data class Minus(val expression: Expression) : Operator()
+    
+    /**
+     * Represents the inverse value of [expression]. Typically, this operator is used to flip the expression's boolean
+     * value.
+     */
+    data class Not(val expression: Expression) : Operator()
     
     // COMPARISON OPERATORS
     
@@ -147,12 +152,6 @@ sealed class Operator : Expression()
      * determine whether one *or* the other expression evaluate to `true`.
      */
     data class Xor(val lhs: Expression, val rhs: Expression) : Operator()
-    
-    /**
-     * Performs a logical `not` operation on the given [expression]. Typically, this operator is used to flip the
-     * expression's boolean value.
-     */
-    data class Not(val expression: Expression) : Operator()
     
     // ARITHMETIC OPERATORS
     

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
@@ -59,6 +59,7 @@ enum class SymbolType(val symbol: String)
     
     // Structural components
     ARROW("->"),
+    CATCH("?"),
     CLOSE_BRACE("}"),
     CLOSE_BRACKET("]"),
     CLOSE_PARENTHESIS(")"),
@@ -68,6 +69,7 @@ enum class SymbolType(val symbol: String)
     OPEN_BRACKET("["),
     OPEN_PARENTHESIS("("),
     PERIOD("."),
+    RAISE("!"),
     SEMICOLON(";"),
     
     // Assignment operators
@@ -96,7 +98,7 @@ enum class SymbolType(val symbol: String)
     
     // Logical operators
     AND("&&"),
-    NOT("!"),
+    NOT("~"),
     OR("||"),
     XOR("^^"),
 }

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
@@ -93,7 +93,7 @@ enum class SymbolType(val symbol: String)
     GREATER_EQUAL(">="),
     LESS("<"),
     LESS_EQUAL("<="),
-    NOT_EQUAL("!="),
+    NOT_EQUAL("~="),
     THREE_WAY("<=>"),
     
     // Logical operators

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Expressions.kt
@@ -66,8 +66,8 @@ private fun mergeInfix(lhs: Expression, operator: SymbolType, rhs: Expression): 
 private fun mergePrefix(operator: SymbolType, rhs: Expression): Expression = when (operator)
 {
     SymbolType.NOT   -> Operator.Not(rhs)
-    SymbolType.PLUS  -> Operator.UnaryPlus(rhs)
-    SymbolType.MINUS -> Operator.UnaryMinus(rhs)
+    SymbolType.PLUS  -> Operator.Plus(rhs)
+    SymbolType.MINUS -> Operator.Minus(rhs)
     else             -> throw IllegalStateException("Illegal operator $operator when parsing prefix operator")
 }
 

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -37,8 +37,8 @@ fun Any.toPar(name: Name? = null) = Parameter(name, toExp())
 
 // Generates expressions from operations
 fun opNot(that: Any) = Operator.Not(that.toExp())
-fun opPlus(that: Any) = Operator.UnaryPlus(that.toExp())
-fun opMinus(that: Any) = Operator.UnaryMinus(that.toExp())
+fun opPlus(that: Any) = Operator.Plus(that.toExp())
+fun opMinus(that: Any) = Operator.Minus(that.toExp())
 infix fun Any.opEq(that: Any) = Operator.Equal(toExp(), that.toExp())
 infix fun Any.opNe(that: Any) = Operator.NotEqual(toExp(), that.toExp())
 infix fun Any.opLe(that: Any) = Operator.LessEqual(toExp(), that.toExp())

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -54,6 +54,8 @@ infix fun Any.opSub(that: Any) = Operator.Subtract(toExp(), that.toExp())
 infix fun Any.opMul(that: Any) = Operator.Multiply(toExp(), that.toExp())
 infix fun Any.opDiv(that: Any) = Operator.Divide(toExp(), that.toExp())
 infix fun Any.opMod(that: Any) = Operator.Modulo(toExp(), that.toExp())
+infix fun Any.opCatch(that: Any) = Operator.Catch(toExp(), that.toExp())
+infix fun Any.opRaise(that: Any) = Operator.Raise(toExp(), that.toExp())
 
 // Generates assignment from operations
 infix fun Name.assign(that: Any) = Assignment.Assign(this, that.toExp())

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
@@ -54,7 +54,7 @@ class TestParserExpression
         tester.parse("1 || 2").isChain(1, 1, 1).isValue(1 opOr 2).resets()
         tester.parse("1 ^^ 2").isChain(1, 1, 1).isValue(1 opXor 2).resets()
         tester.parse("1 == 2").isChain(1, 1, 1).isValue(1 opEq 2).resets()
-        tester.parse("1 != 2").isChain(1, 1, 1).isValue(1 opNe 2).resets()
+        tester.parse("1 ~= 2").isChain(1, 1, 1).isValue(1 opNe 2).resets()
         tester.parse("1 < 2").isChain(1, 1, 1).isValue(1 opLt 2).resets()
         tester.parse("1 <= 2").isChain(1, 1, 1).isValue(1 opLe 2).resets()
         tester.parse("1 > 2").isChain(1, 1, 1).isValue(1 opGt 2).resets()
@@ -65,6 +65,10 @@ class TestParserExpression
         tester.parse("~1").isChain(0, 1, 1).isValue(opNot(1))
         tester.parse("+1").isChain(0, 1, 1).isValue(opPlus(1))
         tester.parse("-1").isChain(0, 1, 1).isValue(opMinus(1))
+        
+        // Error
+        tester.parse("1 ! 2").isChain(1, 1, 1).isValue(1 opRaise 2)
+        tester.parse("1 ? 2").isChain(1, 1, 1).isValue(1 opCatch 2)
     }
     
     @Test
@@ -86,6 +90,8 @@ class TestParserExpression
         tester.parse("1 ++ 2").step(4).isDone().isValue(1 opAdd opPlus(2))
         tester.parse("~1 * -2").step(5).isDone().isValue(opNot(1) opMul opMinus(2))
         tester.parse("-(1 * 2)").step(6).isDone().isValue(opMinus(1 opMul 2))
+        tester.parse("1 ! 2 + 3").step(5).isDone().isValue(1 opRaise (2 opAdd 3))
+        tester.parse("1 ? 2 + 3").step(5).isDone().isValue(1 opCatch (2 opAdd 3))
     }
     
     @Test

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
@@ -62,7 +62,7 @@ class TestParserExpression
         tester.parse("1 <=> 2").isChain(1, 1, 1).isValue(1 opTw 2).resets()
         
         // Unary
-        tester.parse("!1").isChain(0, 1, 1).isValue(opNot(1))
+        tester.parse("~1").isChain(0, 1, 1).isValue(opNot(1))
         tester.parse("+1").isChain(0, 1, 1).isValue(opPlus(1))
         tester.parse("-1").isChain(0, 1, 1).isValue(opMinus(1))
     }
@@ -79,12 +79,12 @@ class TestParserExpression
         tester.parse("1 == (2 && 3)").step(7).isDone().isValue(1 opEq (2 opAnd 3))
         
         // Unary
-        tester.parse("!!1").step(3).isDone().isValue(opNot(opNot(1)))
+        tester.parse("~~1").step(3).isDone().isValue(opNot(opNot(1)))
         tester.parse("+-1").step(3).isDone().isValue(opPlus(opMinus(1)))
         
         // Mixed
         tester.parse("1 ++ 2").step(4).isDone().isValue(1 opAdd opPlus(2))
-        tester.parse("!1 * -2").step(5).isDone().isValue(opNot(1) opMul opMinus(2))
+        tester.parse("~1 * -2").step(5).isDone().isValue(opNot(1) opMul opMinus(2))
         tester.parse("-(1 * 2)").step(6).isDone().isValue(opMinus(1 opMul 2))
     }
     


### PR DESCRIPTION
Closes #36.

This merge request implements parsing of the raise and catch operators. In doing so, the `!` symbol has become overloaded to mean two different things, so instead `~` becomes the symbol for `not` for the moment. Future considerations may be to replace usage of this symbol with `not` for more explicitness and to improve typing experience on certain keyboard layouts.