### PR TITLE
Add parsing of if statement

### DIFF
--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -115,9 +115,16 @@ fun parOf(
 )
 
 /**
+ * Generates a branch structure from the provided input parameters.
+ */
+fun branchOf(predicate: Any, success: Scope, failure: Scope? = null) =
+    Control.Branch(predicate.toExp(), success, failure)
+
+/**
  * Generates a scope definition from the provided input parameters.
  */
-fun scopeOf(isBraced: Boolean, vararg statements: Statement) = Scope(isBraced, statements.toList())
+fun scopeOf(isBraced: Boolean, vararg statements: Statement) =
+    Scope(isBraced, statements.toList())
 
 /**
  * To simplify testing of the parsing of source code for any particular pattern [factory], a helper class is provided.

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
@@ -18,6 +18,12 @@ class TestParserStatement
         tester.parse("a *= 1").isWip(2).isOk(1).isDone().isValue("a" assignMul 1)
         tester.parse("a %= 1").isWip(2).isOk(1).isDone().isValue("a" assignMod 1)
         tester.parse("a /= 1").isWip(2).isOk(1).isDone().isValue("a" assignDiv 1)
+        
+        // Control flow
+        tester.parse("if 1 a = 2").isWip(4).isOk(1).isDone()
+            .isValue(branchOf(1, scopeOf(isBraced = false, "a" assign 2)))
+        tester.parse("if 1 {} else a = 2").isWip(3).isOk(1).isWip(3).isOk(1).isDone()
+            .isValue(branchOf(1, scopeOf(isBraced = true), scopeOf(isBraced = false, "a" assign 2)))
     }
     
     @Test


### PR DESCRIPTION
This merge request introduces a parser for the `if` statement, enabling conditional branching to be parsed. While the parser does not explicitly handle arbitrary number of else clauses in an `if-elseif-else` chain, it does so implicitly since the braces are optional in scopes.