### PR TITLE
Implement parsing of return statement

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Definitions.kt
@@ -81,6 +81,7 @@ data class Function(
     val errorType: Name?,
     val parameters: List<FunctionParameter>,
     val visibility: Visibility,
+    val scope: Scope,
 ) : Definition()
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
@@ -51,6 +51,7 @@ enum class SymbolType(val symbol: String)
     IN("in"),
     MUT("mut"),
     PUB("pub"),
+    RETURN_VALUE("return"),
     RETURN_ERROR("raise"),
     TRUE("true"),
     TYPE("type"),

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Definitions.kt
@@ -75,6 +75,7 @@ class ParserFunctionDefinition : Parser<Function>
         "error" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
         "value" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ARROW), "type" to ParserName())),
         "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
+        "statements" to ParserRepeating(ParserStatement()),
         "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
     )
     
@@ -85,8 +86,9 @@ class ParserFunctionDefinition : Parser<Function>
             name = values.produce("name") ?: return null,
             valueType = values.produce<Parsers>("value")?.produce("type"),
             errorType = values.produce<Parsers>("error")?.produce("type"),
-            parameters = values.produce("parameters") ?: emptyList(),
+            parameters = values.produce("parameters") ?: return null,
             visibility = visibilityOf(values.produce("visibility")),
+            scope = Scope(true, values.produce("statements") ?: return null),
         )
     }
     

--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Statements.kt
@@ -32,6 +32,7 @@ class ParserStatement : Parser<Statement>
         ParserAssignment(),
         ParserBranch(),
         ParserRaise(),
+        ParserReturn(),
     )
     
     override fun produce(): Statement? = parser.produce()
@@ -143,6 +144,28 @@ private class ParserRaise : Parser<Statement>
     {
         val expression = parser.produce().produce<Expression>("expression") ?: return null
         return Control.Raise(expression)
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
+    override fun reset() = parser.reset()
+}
+
+/**
+ * Parses a single return control flow from the provided token.
+ */
+private class ParserReturn : Parser<Statement>
+{
+    private val parser = ParserSequence(
+        "raise" to ParserSymbol(SymbolType.RETURN_VALUE),
+        "expression" to ParserExpression(),
+    )
+    
+    override fun produce(): Statement
+    {
+        val expression = parser.produce().produce<Expression>("expression")
+        // TODO: The magic string `_` should not be used. Use the type-information of the function to remove it
+        return if (expression == Access.Variable("_")) Control.Return(null) else Control.Return(expression)
     }
     
     override fun skipable(): Boolean = false

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -67,6 +67,7 @@ infix fun Name.assignDiv(that: Any) = Assignment.AssignDivide(this, that.toExp()
 
 // Generates control flow
 fun raiseOf(expression: Any) = Control.Raise(expression.toExp())
+fun returnOf(expression: Any? = null) = Control.Return(expression?.toExp())
 
 /**
  * Generates variable definition from the provided input parameters.
@@ -94,12 +95,14 @@ fun funOf(
     errType: Name? = null,
     vis: Visibility = Visibility.PRIVATE,
     params: List<FunctionParameter> = emptyList(),
+    scope: Scope = scopeOf(true),
 ) = Function(
     name = name,
     valueType = valType,
     errorType = errType,
     parameters = params,
     visibility = vis,
+    scope = scope,
 )
 
 /**

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestDefinitions.kt
@@ -75,6 +75,15 @@ class TestParserFunctionDefinition
     }
     
     @Test
+    fun `Given return statement, when parsing, then correctly parsed`()
+    {
+        tester.parse("fun f() { return _ }").isChain(7, 1)
+            .isValue(funOf("f", valType = null, scope = scopeOf(true, returnOf())))
+        tester.parse("fun f() -> Int { return 0 }").isChain(9, 1)
+            .isValue(funOf("f", valType = "Int", scope = scopeOf(true, returnOf(0))))
+    }
+    
+    @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
@@ -24,8 +24,10 @@ class TestParserStatement
             .isValue(branchOf(1, scopeOf(isBraced = false, "a" assign 2)))
         tester.parse("if 1 {} else a = 2").isWip(3).isOk(1).isWip(3).isOk(1).isDone()
             .isValue(branchOf(1, scopeOf(isBraced = true), scopeOf(isBraced = false, "a" assign 2)))
-        
+    
         tester.parse("raise 1").isWip(1).isOk(1).isDone().isValue(raiseOf(1))
+        tester.parse("return 1").isWip(1).isOk(1).isDone().isValue(returnOf(1))
+        tester.parse("return _").isWip(1).isOk(1).isDone().isValue(returnOf())
     }
     
     @Test


### PR DESCRIPTION
Implements the initial parsing of return statements. While the implementation is not fully adequate (requires a magic identifier `_`), it forms the start. Future expansions on the return statement will allow constructs like `if condition return do_work()` do behave correctly depending on whether the function returns a value or not.