### PR TITLE
Implement parsing of function call statements

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/parser/patterns/Statements.kt
@@ -31,6 +31,7 @@ class ParserStatement : Parser<Statement>
     private val parser = ParserAnyOf(
         ParserAssignment(),
         ParserBranch(),
+        ParserCall(),
         ParserRaise(),
         ParserReturn(),
     )
@@ -169,6 +170,21 @@ private class ParserReturn : Parser<Statement>
     }
     
     override fun skipable(): Boolean = false
+    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
+    override fun reset() = parser.reset()
+}
+
+/**
+ * Parses a single expression statement from the provided token. Note that the parser does not implement analysis to
+ * determine whether the expression has any value or error types.
+ */
+private class ParserCall : Parser<Statement>
+{
+    // TODO: Not a correct implementation of the parser - must also function with error handling
+    private val parser = ParserFunctionExpression()
+    
+    override fun produce(): Statement? = parser.produce()?.let { Control.Call(it) }
+    override fun skipable(): Boolean = parser.skipable()
     override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
     override fun reset() = parser.reset()
 }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -65,7 +65,8 @@ infix fun Name.assignMul(that: Any) = Assignment.AssignMultiply(this, that.toExp
 infix fun Name.assignMod(that: Any) = Assignment.AssignModulo(this, that.toExp())
 infix fun Name.assignDiv(that: Any) = Assignment.AssignDivide(this, that.toExp())
 
-// Generates control flow
+// Generates statements
+fun callOf(expression: Any) = Control.Call(expression.toExp())
 fun raiseOf(expression: Any) = Control.Raise(expression.toExp())
 fun returnOf(expression: Any? = null) = Control.Return(expression?.toExp())
 

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
@@ -28,13 +28,15 @@ class TestParserStatement
         tester.parse("raise 1").isWip(1).isOk(1).isDone().isValue(raiseOf(1))
         tester.parse("return 1").isWip(1).isOk(1).isDone().isValue(returnOf(1))
         tester.parse("return _").isWip(1).isOk(1).isDone().isValue(returnOf())
+        
+        // Function call
+        tester.parse("a()").isWip(2).isOk(1).isDone().isValue(callOf("a".toFun()))
     }
     
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("a").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("a =").isWip(2).isBad { ParseError.UnexpectedToken(EndOfFile) }
     }
 }


### PR DESCRIPTION
This is the initial implementation of the call statement. The full implementation is not provided, and is instead left as future work. Note that the parser does not contain sufficient amount of information to determine whether the call statement has any value or error types returned; such analysis is left as responsibility of the analyzer.