### PR TITLE
Implement the when expression

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/ast/Expressions.kt
@@ -194,3 +194,14 @@ sealed class Operator : Expression()
      */
     data class Raise(val lhs: Expression, val rhs: Expression) : Operator()
 }
+
+/**
+ * Specifies a conditional branching on the given [expression], where exactly one of the [branches] are chosen. If none
+ * of the conditions among all branches evaluate to true, the [default] expression is selected instead. The default
+ * expression may only be omitted when all possible conditions are provably covered by the compiler.
+ */
+data class When(
+    val expression: Expression,
+    val branches: List<Pair<Expression, Expression>>,
+    val default: Expression?,
+) : Expression()

--- a/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/lexer/Tokens.kt
@@ -57,6 +57,7 @@ enum class SymbolType(val symbol: String)
     TYPE("type"),
     VAL("val"),
     VAR("var"),
+    WHEN("when"),
     WHILE("while"),
     
     // Structural components

--- a/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/Helpers.kt
@@ -65,7 +65,7 @@ infix fun Name.assignMul(that: Any) = Assignment.AssignMultiply(this, that.toExp
 infix fun Name.assignMod(that: Any) = Assignment.AssignModulo(this, that.toExp())
 infix fun Name.assignDiv(that: Any) = Assignment.AssignDivide(this, that.toExp())
 
-// Generates statements
+// Generates statements from expressions
 fun callOf(expression: Any) = Control.Call(expression.toExp())
 fun raiseOf(expression: Any) = Control.Raise(expression.toExp())
 fun returnOf(expression: Any? = null) = Control.Return(expression?.toExp())
@@ -122,10 +122,16 @@ fun parOf(
 )
 
 /**
- * Generates a branch structure from the provided input parameters.
+ * Generates a branch statement from the provided input parameters.
  */
-fun branchOf(predicate: Any, success: Scope, failure: Scope? = null) =
+fun ifOf(predicate: Any, success: Scope, failure: Scope? = null) =
     Control.Branch(predicate.toExp(), success, failure)
+
+/**
+ * Generates a branch expression from the provided input parameters.
+ */
+fun whenOf(expression: Any, vararg branches: Pair<Any, Any>, default: Any? = null) =
+    When(expression.toExp(), branches.map { it.first.toExp() to it.second.toExp() }, default?.toExp())
 
 /**
  * Generates a scope definition from the provided input parameters.

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestExpressions.kt
@@ -69,6 +69,11 @@ class TestParserExpression
         // Error
         tester.parse("1 ! 2").isChain(1, 1, 1).isValue(1 opRaise 2)
         tester.parse("1 ? 2").isChain(1, 1, 1).isValue(1 opCatch 2)
+        
+        // When
+        tester.parse("when 1 2 -> 3").isChain(0, 4, 1).isValue(whenOf(1, 2 to 3))
+        tester.parse("when 1 2 -> 3 4 -> 5").isWip(4).isChain(1, 2, 1).isValue(whenOf(1, 2 to 3, 4 to 5))
+        tester.parse("when 1 2 -> 3 else 4").isWip(4).isChain(1, 1, 1).isValue(whenOf(1, 2 to 3, default = 4))
     }
     
     @Test
@@ -99,6 +104,7 @@ class TestParserExpression
     {
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("*").isBad { ParseError.UnexpectedToken(it[0]) }
+        tester.parse("when").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
         
         // Structural errors
         tester.parse("(").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }

--- a/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/parser/patterns/TestStatements.kt
@@ -21,9 +21,9 @@ class TestParserStatement
         
         // Control flow
         tester.parse("if 1 a = 2").isWip(4).isOk(1).isDone()
-            .isValue(branchOf(1, scopeOf(isBraced = false, "a" assign 2)))
+            .isValue(ifOf(1, scopeOf(isBraced = false, "a" assign 2)))
         tester.parse("if 1 {} else a = 2").isWip(3).isOk(1).isWip(3).isOk(1).isDone()
-            .isValue(branchOf(1, scopeOf(isBraced = true), scopeOf(isBraced = false, "a" assign 2)))
+            .isValue(ifOf(1, scopeOf(isBraced = true), scopeOf(isBraced = false, "a" assign 2)))
     
         tester.parse("raise 1").isWip(1).isOk(1).isDone().isValue(raiseOf(1))
         tester.parse("return 1").isWip(1).isOk(1).isDone().isValue(returnOf(1))


### PR DESCRIPTION
Introduces an initial implementation of the `when` expression. This expression enables the programmer to switch on any expression, and can match the expression against any number of conditions. The first matching condition is chosen, and the branch is the evaluated value of the `when` expression.