### PR TITLE
Introduce initial intermediate representation structure

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/core/Print.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/core/Print.kt
@@ -1,7 +1,7 @@
 package com.github.derg.transpiler.core
 
-import com.github.derg.transpiler.ast.*
-import com.github.derg.transpiler.ast.Function
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.ast.Function
 
 /**
  * Pretty-prints the entire abstract syntax tree defined from [this] node.

--- a/src/main/kotlin/com/github/derg/transpiler/phases/lexer/Tokenizer.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/lexer/Tokenizer.kt
@@ -1,7 +1,8 @@
-package com.github.derg.transpiler.lexer
+package com.github.derg.transpiler.phases.lexer
 
 import com.github.derg.transpiler.core.Localized
 import com.github.derg.transpiler.core.Location
+import com.github.derg.transpiler.source.lexeme.*
 import com.github.derg.transpiler.util.indexOfFirstOrNull
 import com.github.derg.transpiler.util.indexOfOrNull
 import com.github.derg.transpiler.util.substringFrom

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -1,10 +1,9 @@
-package com.github.derg.transpiler.parser
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.Segment
-import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.lexer.Token
-import com.github.derg.transpiler.lexer.tokenize
-import com.github.derg.transpiler.parser.patterns.ParserSegment
+import com.github.derg.transpiler.phases.lexer.tokenize
+import com.github.derg.transpiler.source.ast.Segment
+import com.github.derg.transpiler.source.lexeme.EndOfFile
+import com.github.derg.transpiler.source.lexeme.Token
 import com.github.derg.transpiler.util.Result
 import com.github.derg.transpiler.util.fold
 import com.github.derg.transpiler.util.valueOr

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
@@ -1,9 +1,6 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.lexer.Token
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.ParseOk
-import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.source.lexeme.Token
 import com.github.derg.transpiler.util.*
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
@@ -1,13 +1,10 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.*
-import com.github.derg.transpiler.ast.Function
 import com.github.derg.transpiler.core.Name
-import com.github.derg.transpiler.lexer.SymbolType
-import com.github.derg.transpiler.lexer.Token
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.ParseOk
-import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.ast.Function
+import com.github.derg.transpiler.source.lexeme.SymbolType
+import com.github.derg.transpiler.source.lexeme.Token
 import com.github.derg.transpiler.util.Result
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
@@ -1,6 +1,8 @@
 package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.core.Name
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Visibility
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.ast.Function
 import com.github.derg.transpiler.source.lexeme.SymbolType

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
@@ -1,11 +1,8 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.*
 import com.github.derg.transpiler.core.Name
-import com.github.derg.transpiler.lexer.*
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.ParseOk
-import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.lexeme.*
 import com.github.derg.transpiler.util.Result
 import com.github.derg.transpiler.util.failureOf
 import com.github.derg.transpiler.util.successOf

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -1,12 +1,9 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.*
 import com.github.derg.transpiler.core.Name
-import com.github.derg.transpiler.lexer.SymbolType
-import com.github.derg.transpiler.lexer.Token
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.ParseOk
-import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.lexeme.SymbolType
+import com.github.derg.transpiler.source.lexeme.Token
 import com.github.derg.transpiler.util.Result
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
@@ -1,13 +1,10 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.core.Name
-import com.github.derg.transpiler.lexer.Identifier
-import com.github.derg.transpiler.lexer.Symbol
-import com.github.derg.transpiler.lexer.SymbolType
-import com.github.derg.transpiler.lexer.Token
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.ParseOk
-import com.github.derg.transpiler.parser.Parser
+import com.github.derg.transpiler.source.lexeme.Identifier
+import com.github.derg.transpiler.source.lexeme.Symbol
+import com.github.derg.transpiler.source.lexeme.SymbolType
+import com.github.derg.transpiler.source.lexeme.Token
 import com.github.derg.transpiler.util.Result
 import com.github.derg.transpiler.util.failureOf
 import com.github.derg.transpiler.util.successOf

--- a/src/main/kotlin/com/github/derg/transpiler/source/Enums.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/Enums.kt
@@ -1,0 +1,51 @@
+package com.github.derg.transpiler.source
+
+/**
+ * Encapsulation of data and functionality is achieved through visibility. Certain functionality, behavior, and state
+ * may be concealed behind an abstraction, where anything outside the abstraction cannot see the internal behavior or
+ * state.
+ *
+ * Visibilities are hierarchical in nature. Everything which is accessible under the public domain is also accessible by
+ * everything which could access protected elements, and similarly for everything which has access to private elements.
+ */
+enum class Visibility
+{
+    /**
+     * The object is accessible to everything within the same module as the object was declared in. The object will not
+     * be visible to anything outside the current module.
+     */
+    PUBLIC,
+    
+    /**
+     * The object is only accessible to the current type in which the object was declared. For example, a private
+     * variable may only be accessed by the object where the variable was declared.
+     */
+    PRIVATE,
+}
+
+/**
+ * The kind of variable determines what is permitted regarding the data the variable holds. The kind specifies the
+ * variable mutability level, restricting the variable from never-changing, to fully mutable.
+ */
+enum class Mutability
+{
+    /**
+     * The variable is considered a constant. The value can never change, and the properties associated with the value
+     * cannot change either. The variable is considered deeply constant, and the user cannot assume that its memory
+     * address will remain constant. All variables which are constant may be inlined, or statically computed to other
+     * values at compile time, wherever possible.
+     */
+    VALUE,
+    
+    /**
+     * The variable is considered unchanging and can never change. However, the variable is still possible to mutate by
+     * invoking mutating functions or writing different values to the variable properties.
+     */
+    VARYING,
+    
+    /**
+     * The variable is considered fully mutable and can change in every imaginable way. The variable may be re-assigned
+     * a different value, and mutated by either function calls or by updating the variable properties.
+     */
+    MUTABLE,
+}

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Definitions.kt
@@ -1,4 +1,4 @@
-package com.github.derg.transpiler.ast
+package com.github.derg.transpiler.source.ast
 
 import com.github.derg.transpiler.core.Name
 

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Definitions.kt
@@ -1,6 +1,8 @@
 package com.github.derg.transpiler.source.ast
 
 import com.github.derg.transpiler.core.Name
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Visibility
 
 /**
  * Variables are units which hold a specific [value] and associates the value with a specific [name]. Variables may

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Expressions.kt
@@ -1,4 +1,4 @@
-package com.github.derg.transpiler.ast
+package com.github.derg.transpiler.source.ast
 
 import com.github.derg.transpiler.core.Name
 

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
@@ -1,4 +1,4 @@
-package com.github.derg.transpiler.ast
+package com.github.derg.transpiler.source.ast
 
 import com.github.derg.transpiler.core.Name
 

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
@@ -3,56 +3,6 @@ package com.github.derg.transpiler.source.ast
 import com.github.derg.transpiler.core.Name
 
 /**
- * Encapsulation of data and functionality is achieved through visibility. Certain functionality, behavior, and state
- * may be concealed behind an abstraction, where anything outside the abstraction cannot see the internal behavior or
- * state.
- *
- * Visibilities are hierarchical in nature. Everything which is accessible under the public domain is also accessible by
- * everything which could access protected elements, and similarly for everything which has access to private elements.
- */
-enum class Visibility
-{
-    /**
-     * The object is accessible to everything within the same module as the object was declared in. The object will not
-     * be visible to anything outside the current module.
-     */
-    PUBLIC,
-    
-    /**
-     * The object is only accessible to the current type in which the object was declared. For example, a private
-     * variable may only be accessed by the object where the variable was declared.
-     */
-    PRIVATE,
-}
-
-/**
- * The kind of variable determines what is permitted regarding the data the variable holds. The kind specifies the
- * variable mutability level, restricting the variable from never-changing, to fully mutable.
- */
-enum class Mutability
-{
-    /**
-     * The variable is considered a constant. The value can never change, and the properties associated with the value
-     * cannot change either. The variable is considered deeply constant, and the user cannot assume that its memory
-     * address will remain constant. All variables which are constant may be inlined, or statically computed to other
-     * values at compile time, wherever possible.
-     */
-    VALUE,
-    
-    /**
-     * The variable is considered unchanging and can never change. However, the variable is still possible to mutate by
-     * invoking mutating functions or writing different values to the variable properties.
-     */
-    VARYING,
-    
-    /**
-     * The variable is considered fully mutable and can change in every imaginable way. The variable may be re-assigned
-     * a different value, and mutated by either function calls or by updating the variable properties.
-     */
-    MUTABLE,
-}
-
-/**
  * Function parameters consists of a single [expression] which specifies which value they have, and optionally the
  * [name] of the parameters the [expression] is associated with. Parameters must be specified in the correct order,
  * although the ordering may be ignored if the parameters are named instead.

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Nodes.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Nodes.kt
@@ -1,4 +1,4 @@
-package com.github.derg.transpiler.ast
+package com.github.derg.transpiler.source.ast
 
 /**
  * Every single element in the source code may be represented as a node in the abstract syntax tree. The nodes do not

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
@@ -50,14 +50,14 @@ sealed interface Control : Statement
      * Splits the execution based on the [predicate]. If the predicate returns a `true` value, the [success] path is
      * chosen, otherwise the [failure] path is chosen (if specified).
      */
-    data class Branch(val predicate: Expression, val success: Scope, val failure: Scope?) : Statement
+    data class Branch(val predicate: Expression, val success: Scope, val failure: Scope?) : Control
     
     /**
      * While ordinarily expressions are not permitted to be statements, functions may be invoked directly as statements
      * under certain circumstances. The [expression] is not permitted to resolve down to any value, it must resolve to
      * something which does not have a type, and does not raise any error.
      */
-    data class Call(val expression: Expression) : Statement
+    data class Call(val expression: Expression) : Control
     
     /**
      * Specifies that a function should raise a specific [expression]. The raise statement functions similarly to the
@@ -65,12 +65,12 @@ sealed interface Control : Statement
      * function, this usually indicates that the function has failed to uphold its contract and produced a value which
      * does not conform to the expectations of the caller.
      */
-    data class Raise(val expression: Expression) : Statement
+    data class Raise(val expression: Expression) : Control
     
     /**
      * Specifies that a function should return a specific [expression]. The return statement marks the point where the
      * execution is resumed to the caller of the function, executing nothing else in the body of the function. Returning
      * a value from a function indicates usually that the function has succeeded in producing a usable value.
      */
-    data class Return(val expression: Expression?) : Statement
+    data class Return(val expression: Expression?) : Control
 }

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
@@ -1,4 +1,4 @@
-package com.github.derg.transpiler.ast
+package com.github.derg.transpiler.source.ast
 
 import com.github.derg.transpiler.core.Name
 

--- a/src/main/kotlin/com/github/derg/transpiler/source/lexeme/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/lexeme/Tokens.kt
@@ -1,4 +1,4 @@
-package com.github.derg.transpiler.lexer
+package com.github.derg.transpiler.source.lexeme
 
 /**
  * A single token represents a single lexeme in the source code. Tokens may be extracted from the source code in various

--- a/src/main/kotlin/com/github/derg/transpiler/source/lir/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/lir/Definitions.kt
@@ -1,0 +1,35 @@
+package com.github.derg.transpiler.source.lir
+
+import com.github.derg.transpiler.core.Id
+import com.github.derg.transpiler.core.Name
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Visibility
+
+data class Module(
+    val name: Name,
+    val id: Id,
+) : Symbol
+
+data class Variable(
+    val name: Name,
+    val id: Id,
+    val type: Id,
+    val visibility: Visibility,
+    val mutability: Mutability,
+) : Symbol
+
+data class Function(
+    val name: Name,
+    val id: Id,
+    val valueType: Id,
+    val errorType: Id,
+    val parameters: List<Parameter>,
+    val visibility: Visibility,
+) : Symbol
+
+data class Parameter(
+    val name: Name,
+    val id: Id,
+    val type: Id,
+    val mutability: Mutability,
+) : Symbol

--- a/src/main/kotlin/com/github/derg/transpiler/source/lir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/lir/Symbols.kt
@@ -1,0 +1,7 @@
+package com.github.derg.transpiler.source.lir
+
+/**
+ * All named objects within a codebase is known as a symbol. The symbols are given an identifier, which allows them to
+ * be retrieved at a later time.
+ */
+sealed interface Symbol

--- a/src/main/kotlin/com/github/derg/transpiler/source/lir/Tables.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/lir/Tables.kt
@@ -1,4 +1,7 @@
-package com.github.derg.transpiler.core
+package com.github.derg.transpiler.source.lir
+
+import com.github.derg.transpiler.core.Id
+import com.github.derg.transpiler.core.Name
 
 /**
  * Unique identifier for each and every identifiable object. No two objects will ever be granted the same id.

--- a/src/test/kotlin/com/github/derg/transpiler/phases/lexer/TestTokenizer.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/lexer/TestTokenizer.kt
@@ -1,8 +1,9 @@
-package com.github.derg.transpiler.lexer
+package com.github.derg.transpiler.phases.lexer
 
 import com.github.derg.transpiler.core.Localized
 import com.github.derg.transpiler.core.Location
-import com.github.derg.transpiler.lexer.SymbolType.*
+import com.github.derg.transpiler.source.lexeme.*
+import com.github.derg.transpiler.source.lexeme.SymbolType.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/Helpers.kt
@@ -2,6 +2,8 @@ package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.core.Name
 import com.github.derg.transpiler.phases.lexer.tokenize
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Visibility
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.ast.Function
 import com.github.derg.transpiler.source.lexeme.EndOfFile

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/Helpers.kt
@@ -1,13 +1,11 @@
-package com.github.derg.transpiler.parser
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.*
-import com.github.derg.transpiler.ast.Function
 import com.github.derg.transpiler.core.Name
-import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.lexer.Token
-import com.github.derg.transpiler.lexer.tokenize
-import com.github.derg.transpiler.parser.patterns.Parsers
-import com.github.derg.transpiler.parser.patterns.produce
+import com.github.derg.transpiler.phases.lexer.tokenize
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.ast.Function
+import com.github.derg.transpiler.source.lexeme.EndOfFile
+import com.github.derg.transpiler.source.lexeme.Token
 import com.github.derg.transpiler.util.failureOf
 import com.github.derg.transpiler.util.isSuccess
 import com.github.derg.transpiler.util.successOf

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
@@ -1,5 +1,7 @@
 package com.github.derg.transpiler.phases.parser
 
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Visibility
 import com.github.derg.transpiler.source.ast.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
@@ -1,6 +1,6 @@
-package com.github.derg.transpiler.parser
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.*
+import com.github.derg.transpiler.source.ast.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
@@ -1,12 +1,8 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.lexer.Numeric
-import com.github.derg.transpiler.lexer.SymbolType
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.Tester
-import com.github.derg.transpiler.parser.hasValue
-import com.github.derg.transpiler.parser.toExp
+import com.github.derg.transpiler.source.lexeme.EndOfFile
+import com.github.derg.transpiler.source.lexeme.Numeric
+import com.github.derg.transpiler.source.lexeme.SymbolType
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
@@ -1,9 +1,9 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.ast.Mutability
-import com.github.derg.transpiler.ast.Visibility
-import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.parser.*
+import com.github.derg.transpiler.phases.parser.*
+import com.github.derg.transpiler.source.ast.Mutability
+import com.github.derg.transpiler.source.ast.Visibility
+import com.github.derg.transpiler.source.lexeme.EndOfFile
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
@@ -1,8 +1,8 @@
 package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.phases.parser.*
-import com.github.derg.transpiler.source.ast.Mutability
-import com.github.derg.transpiler.source.ast.Visibility
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Visibility
 import com.github.derg.transpiler.source.lexeme.EndOfFile
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
@@ -1,7 +1,6 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.parser.*
+import com.github.derg.transpiler.source.lexeme.EndOfFile
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
@@ -1,7 +1,6 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.lexer.EndOfFile
-import com.github.derg.transpiler.parser.*
+import com.github.derg.transpiler.source.lexeme.EndOfFile
 import org.junit.jupiter.api.Test
 
 class TestParserStatement

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserTokens.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserTokens.kt
@@ -1,8 +1,6 @@
-package com.github.derg.transpiler.parser.patterns
+package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.lexer.SymbolType
-import com.github.derg.transpiler.parser.ParseError
-import com.github.derg.transpiler.parser.Tester
+import com.github.derg.transpiler.source.lexeme.SymbolType
 import org.junit.jupiter.api.Test
 
 class TestParserName

--- a/src/test/kotlin/com/github/derg/transpiler/source/lir/TestTables.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/lir/TestTables.kt
@@ -1,5 +1,6 @@
-package com.github.derg.transpiler.core
+package com.github.derg.transpiler.source.lir
 
+import com.github.derg.transpiler.core.Id
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
This pull request introduces some primitive structures for holding the internal representation of source code. This is not nearly a finished work, but serves as an initial stepping stone to make further progress. Additionally, some re-structuring of code takes place to ensure the module structure makes more sense with multiple code representations.