### PR TITLE
Clean up parser combiner patterns

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -14,10 +14,10 @@ import com.github.derg.transpiler.util.valueOr
  */
 fun parse(input: String): Segment
 {
-    val parser = ParserSegment()
+    val parser = segmentParser()
     val tokens = tokenize(input).map { it.data } + EndOfFile
     tokens.fold { parser.parse(it) }.valueOr { throw IllegalStateException("Failed parsing token: $it") }
-    return parser.produce()
+    return parser.produce() ?: throw IllegalStateException("Failed to produce segment")
 }
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -14,7 +14,7 @@ import com.github.derg.transpiler.util.valueOr
  */
 fun parse(input: String): Segment
 {
-    val parser = segmentParser()
+    val parser = segmentParserOf()
     val tokens = tokenize(input).map { it.data } + EndOfFile
     tokens.fold { parser.parse(it) }.valueOr { throw IllegalStateException("Failed parsing token: $it") }
     return parser.produce() ?: throw IllegalStateException("Failed to produce segment")

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
@@ -26,29 +26,6 @@ class Parsers(parsers: Map<String, Parser<*>>)
 fun <Type> List<Parsers>.produce(key: String): List<Type> = mapNotNull { it.produce(key) }
 
 /**
- * Parses the token stream in such a way that the underlying parser is only instantiated once required. The [factory]
- * must generate a fresh instance of the parser, and it will be fully removed once the recursive parser resets.
- */
-internal class ParserRecursive<Type>(private val factory: () -> Parser<Type>) : Parser<Type>
-{
-    private var parser: Parser<Type>? = null
-    
-    /**
-     * Actually instantiates the parser - if the parser has already been instantiated, the same instance is used for
-     * further token processing.
-     */
-    private fun parser(): Parser<Type> = parser ?: factory().also { parser = it }
-    
-    override fun skipable(): Boolean = parser().skipable()
-    override fun produce(): Type? = parser?.produce()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser().parse(token)
-    override fun reset()
-    {
-        parser = null
-    }
-}
-
-/**
  * Parses the token stream in such a way that exactly one of the provided parsers parses. If more than a single pattern
  * matches the context, the parser consuming the most tokens is chosen. Ties are not permitted - exactly one parser must
  * be selected as the longest chain.
@@ -248,13 +225,26 @@ class ParserOptional<Type>(private val parser: Parser<Type>) : Parser<Type?>
 }
 
 /**
- * Parses the token stream according to the provided [pattern]. When the pattern is considered satisfied, this parser is
- * also satisfied and may use the [converter] to produce the final output.
+ * Parses the token stream according to the provided pattern [factory]. When the pattern is considered satisfied, this
+ * parser is also satisfied and may use the [mapper] to produce the final output. This parser may be used recursively as
+ * well, i.e. allowing an expression parser to parse another expression while in the middle of parsing.
  */
-class ParserPattern<Type, Out>(private val pattern: Parser<Out>, private val converter: (Out) -> Type?) : Parser<Type>
+class ParserPattern<Type, Out>(private val factory: () -> Parser<Out>, private val mapper: (Out) -> Type?) :
+    Parser<Type>
 {
-    override fun skipable(): Boolean = pattern.skipable()
-    override fun produce(): Type? = pattern.produce()?.let(converter)
-    override fun parse(token: Token): Result<ParseOk, ParseError> = pattern.parse(token)
-    override fun reset() = pattern.reset()
+    private var parser: Parser<Out>? = null
+    
+    /**
+     * Actually instantiates the parser - if the parser has already been instantiated, the same instance is used for
+     * further token processing.
+     */
+    private fun parser(): Parser<Out> = parser ?: factory().also { parser = it }
+    
+    override fun skipable(): Boolean = parser().skipable()
+    override fun produce(): Type? = parser?.produce()?.let(mapper)
+    override fun parse(token: Token): Result<ParseOk, ParseError> = parser().parse(token)
+    override fun reset()
+    {
+        parser = null
+    }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
@@ -246,3 +246,15 @@ class ParserOptional<Type>(private val parser: Parser<Type>) : Parser<Type?>
         isOngoing = false
     }
 }
+
+/**
+ * Parses the token stream according to the provided [pattern]. When the pattern is considered satisfied, this parser is
+ * also satisfied and may use the [converter] to produce the final output.
+ */
+class ParserPattern<Type, Out>(private val pattern: Parser<Out>, private val converter: (Out) -> Type?) : Parser<Type>
+{
+    override fun skipable(): Boolean = pattern.skipable()
+    override fun produce(): Type? = pattern.produce()?.let(converter)
+    override fun parse(token: Token): Result<ParseOk, ParseError> = pattern.parse(token)
+    override fun reset() = pattern.reset()
+}

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
@@ -32,7 +32,7 @@ private fun mutabilityOf(symbol: SymbolType): Mutability = when (symbol)
  * Parses a variable definition from the provided token.
  */
 fun variableParserOf(): Parser<Statement> =
-    ParserPattern(variablePatternOf(), ::variableOutcomeOf)
+    ParserPattern(::variablePatternOf, ::variableOutcomeOf)
 
 private fun variablePatternOf() = ParserSequence(
     "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
@@ -57,7 +57,7 @@ private fun variableOutcomeOf(values: Parsers): Variable?
  * Parses a function definition from the provided token.
  */
 fun functionParserOf(): Parser<Statement> =
-    ParserPattern(functionPatternOf(), ::functionOutcomeOf)
+    ParserPattern(::functionPatternOf, ::functionOutcomeOf)
 
 private fun functionPatternOf() = ParserSequence(
     "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
@@ -89,7 +89,7 @@ private fun functionOutcomeOf(values: Parsers): Function?
  * Parses a function parameter definition from the provided token.
  */
 private fun functionParameterParser(): Parser<Function.Parameter> =
-    ParserPattern(functionParameterPattern(), ::functionParameterOutcome)
+    ParserPattern(::functionParameterPattern, ::functionParameterOutcome)
 
 private fun functionParameterPattern() = ParserSequence(
     "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
@@ -112,7 +112,7 @@ private fun functionParameterOutcome(values: Parsers): Function.Parameter?
  *
  */
 fun segmentParser(): Parser<Segment> =
-    ParserPattern(segmentPattern(), ::segmentOutcome)
+    ParserPattern(::segmentPattern, ::segmentOutcome)
 
 // TODO: Use statements should allow modules to be imported into namespaces
 private fun segmentPattern() = ParserSequence(

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
@@ -6,8 +6,6 @@ import com.github.derg.transpiler.source.Visibility
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.ast.Function
 import com.github.derg.transpiler.source.lexeme.SymbolType
-import com.github.derg.transpiler.source.lexeme.Token
-import com.github.derg.transpiler.util.Result
 
 /**
  * Determines the given visibility from the provided [symbol].
@@ -33,118 +31,101 @@ private fun mutabilityOf(symbol: SymbolType): Mutability = when (symbol)
 /**
  * Parses a variable definition from the provided token.
  */
-class ParserVariableDefinition : Parser<Statement>
+fun variableParserOf(): Parser<Statement> =
+    ParserPattern(variablePatternOf(), ::variableOutcomeOf)
+
+private fun variablePatternOf() = ParserSequence(
+    "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
+    "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
+    "name" to ParserName(),
+    "op" to ParserSymbol(SymbolType.ASSIGN),
+    "value" to expressionParserOf(),
+)
+
+private fun variableOutcomeOf(values: Parsers): Variable?
 {
-    private val parser = ParserSequence(
-        "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
-        "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
-        "name" to ParserName(),
-        "op" to ParserSymbol(SymbolType.ASSIGN),
-        "value" to ParserExpression(),
+    return Variable(
+        name = values.produce("name") ?: return null,
+        type = null,
+        value = values.produce("value") ?: return null,
+        visibility = visibilityOf(values.produce("visibility")),
+        mutability = mutabilityOf(values.produce("mutability") ?: return null),
     )
-    
-    override fun produce(): Definition?
-    {
-        val values = parser.produce()
-        return Variable(
-            name = values.produce("name") ?: return null,
-            type = null,
-            value = values.produce("value") ?: return null,
-            visibility = visibilityOf(values.produce("visibility")),
-            mutability = mutabilityOf(values.produce("mutability") ?: return null),
-        )
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
 }
 
 /**
  * Parses a function definition from the provided token.
  */
-class ParserFunctionDefinition : Parser<Statement>
+fun functionParserOf(): Parser<Statement> =
+    ParserPattern(functionPatternOf(), ::functionOutcomeOf)
+
+private fun functionPatternOf() = ParserSequence(
+    "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
+    "fun" to ParserSymbol(SymbolType.FUN),
+    "name" to ParserName(),
+    "open_parenthesis" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
+    "parameters" to ParserRepeating(functionParameterParser(), ParserSymbol(SymbolType.COMMA)),
+    "close_parenthesis" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
+    "error" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
+    "value" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ARROW), "type" to ParserName())),
+    "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
+    "statements" to ParserRepeating(statementParserOf()),
+    "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
+)
+
+private fun functionOutcomeOf(values: Parsers): Function?
 {
-    private val parser = ParserSequence(
-        "visibility" to ParserOptional(ParserSymbol(SymbolType.PUB)),
-        "fun" to ParserSymbol(SymbolType.FUN),
-        "name" to ParserName(),
-        "open_parenthesis" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
-        "parameters" to ParserRepeating(ParserFunctionParameterDefinition(), ParserSymbol(SymbolType.COMMA)),
-        "close_parenthesis" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
-        "error" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
-        "value" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ARROW), "type" to ParserName())),
-        "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
-        "statements" to ParserRepeating(ParserStatement()),
-        "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
+    return Function(
+        name = values.produce("name") ?: return null,
+        valueType = values.produce<Parsers>("value")?.produce("type"),
+        errorType = values.produce<Parsers>("error")?.produce("type"),
+        parameters = values.produce("parameters") ?: return null,
+        visibility = visibilityOf(values.produce("visibility")),
+        scope = Scope(true, values.produce("statements") ?: return null),
     )
-    
-    override fun produce(): Definition?
-    {
-        val values = parser.produce()
-        return Function(
-            name = values.produce("name") ?: return null,
-            valueType = values.produce<Parsers>("value")?.produce("type"),
-            errorType = values.produce<Parsers>("error")?.produce("type"),
-            parameters = values.produce("parameters") ?: return null,
-            visibility = visibilityOf(values.produce("visibility")),
-            scope = Scope(true, values.produce("statements") ?: return null),
-        )
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
 }
 
 /**
  * Parses a function parameter definition from the provided token.
  */
-private class ParserFunctionParameterDefinition : Parser<Function.Parameter>
+private fun functionParameterParser(): Parser<Function.Parameter> =
+    ParserPattern(functionParameterPattern(), ::functionParameterOutcome)
+
+private fun functionParameterPattern() = ParserSequence(
+    "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
+    "name" to ParserName(),
+    "type" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
+    "val" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ASSIGN), "val" to expressionParserOf())),
+)
+
+private fun functionParameterOutcome(values: Parsers): Function.Parameter?
 {
-    private val parser = ParserSequence(
-        "mutability" to ParserSymbol(SymbolType.VAL, SymbolType.VAR, SymbolType.MUT),
-        "name" to ParserName(),
-        "type" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.COLON), "type" to ParserName())),
-        "val" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.ASSIGN), "val" to ParserExpression())),
+    return Function.Parameter(
+        name = values.produce("name") ?: return null,
+        type = values.produce<Parsers>("type")?.produce("type"),
+        value = values.produce<Parsers>("bal")?.produce("val"),
+        mutability = mutabilityOf(values.produce("mutability") ?: return null),
     )
-    
-    override fun produce(): Function.Parameter?
-    {
-        val values = parser.produce()
-        return Function.Parameter(
-            name = values.produce("name") ?: return null,
-            type = values.produce<Parsers>("type")?.produce("type"),
-            value = values.produce<Parsers>("bal")?.produce("val"),
-            mutability = mutabilityOf(values.produce("mutability") ?: return null),
-        )
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
 }
 
-class ParserSegment : Parser<Segment>
+/**
+ *
+ */
+fun segmentParser(): Parser<Segment> =
+    ParserPattern(segmentPattern(), ::segmentOutcome)
+
+// TODO: Use statements should allow modules to be imported into namespaces
+private fun segmentPattern() = ParserSequence(
+    "module" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.MODULE), "name" to ParserName())),
+    "imports" to ParserRepeating(ParserSequence("sym" to ParserSymbol(SymbolType.USE), "name" to ParserName())),
+    "statements" to ParserRepeating(statementParserOf()),
+)
+
+private fun segmentOutcome(values: Parsers): Segment
 {
-    // TODO: Use statements should allow modules to be imported into namespaces
-    private val parser = ParserSequence(
-        "module" to ParserOptional(ParserSequence("sym" to ParserSymbol(SymbolType.MODULE), "name" to ParserName())),
-        "imports" to ParserRepeating(ParserSequence("sym" to ParserSymbol(SymbolType.USE), "name" to ParserName())),
-        "statements" to ParserRepeating(ParserStatement()),
+    return Segment(
+        module = values.produce<Parsers>("module")?.produce<Name>("name"),
+        imports = values.produce<List<Parsers>>("imports")?.mapNotNull { it.produce<Name>("name") }?.toSet() ?: emptySet(),
+        statements = values.produce("statements") ?: emptyList(),
     )
-    
-    override fun produce(): Segment
-    {
-        val values = parser.produce()
-        return Segment(
-            module = values.produce<Parsers>("module")?.produce<Name>("name"),
-            imports = values.produce<List<Parsers>>("imports")?.mapNotNull { it.produce<Name>("name") }?.toSet() ?: emptySet(),
-            statements = values.produce("statements") ?: emptyList(),
-        )
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
@@ -114,19 +114,19 @@ private fun generateOperatorParser(): Parser<SymbolType> =
  * Parses a single expression from the provided token.
  */
 fun expressionParserOf(): Parser<Expression> =
-    ParserPattern(ParserRecursive { operatorParserOf() }) { it }
+    ParserPattern(::operatorParserOf) { it }
 
 /**
  * Parses a variable access expression from the provided token.
  */
 private fun variableCallParserOf(): Parser<Expression> =
-    ParserPattern(ParserName()) { Access.Variable(it) }
+    ParserPattern(::ParserName) { Access.Variable(it) }
 
 /**
  * Parses a function call expression from the provided token.
  */
 internal fun functionCallParserOf(): Parser<Expression> =
-    ParserPattern(functionCallPatternOf(), ::functionCallOutcomeOf)
+    ParserPattern(::functionCallPatternOf, ::functionCallOutcomeOf)
 
 private fun functionCallPatternOf() = ParserSequence(
     "name" to ParserName(),
@@ -146,7 +146,7 @@ private fun functionCallOutcomeOf(outcome: Parsers): Expression?
  * Parses a subscript call expression from the provided token.
  */
 private fun subscriptCallParserOf(): Parser<Expression> =
-    ParserPattern(subscriptCallPatternOf(), ::subscriptCallOutcomeOf)
+    ParserPattern(::subscriptCallPatternOf, ::subscriptCallOutcomeOf)
 
 private fun subscriptCallPatternOf() = ParserSequence(
     "name" to ParserName(),
@@ -166,7 +166,7 @@ private fun subscriptCallOutcomeOf(values: Parsers): Expression?
  * Parses a function call parameter from the provided token.
  */
 private fun parameterParserOf(): Parser<Parameter> =
-    ParserPattern(parameterPatternOf(), ::parameterOutcomeOf)
+    ParserPattern(::parameterPatternOf, ::parameterOutcomeOf)
 
 private fun parameterPatternOf() = ParserAnyOf(
     ParserSequence("expr" to expressionParserOf()),
@@ -184,11 +184,11 @@ private fun parameterOutcomeOf(values: Parsers): Parameter?
  * Parses an expression from in-between parenthesis from the provided token.
  */
 private fun parenthesisParserOf(): Parser<Expression> =
-    ParserPattern(parenthesisPatternOf(), ::parenthesisOutcomeOf)
+    ParserPattern(::parenthesisPatternOf, ::parenthesisOutcomeOf)
 
 private fun parenthesisPatternOf() = ParserSequence(
     "open" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
-    "expr" to ParserRecursive { operatorParserOf() },
+    "expr" to operatorParserOf(),
     "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
 )
 
@@ -200,11 +200,11 @@ private fun parenthesisOutcomeOf(values: Parsers): Expression? =
  * parsing the stream of tokens.
  */
 private fun prefixOperatorParserOf(): Parser<Expression> =
-    ParserPattern(prefixOperatorPatternOf(), ::prefixOperatorOutcomeOf)
+    ParserPattern(::prefixOperatorPatternOf, ::prefixOperatorOutcomeOf)
 
 private fun prefixOperatorPatternOf() = ParserSequence(
     "op" to ParserSymbol(SymbolType.PLUS, SymbolType.MINUS, SymbolType.NOT),
-    "rhs" to ParserRecursive { generateStandardParser() },
+    "rhs" to generateStandardParser(),
 )
 
 private fun prefixOperatorOutcomeOf(values: Parsers): Expression?
@@ -219,7 +219,7 @@ private fun prefixOperatorOutcomeOf(values: Parsers): Expression?
  * the type of operator, as well as the precedence.
  */
 private fun operatorParserOf(): Parser<Expression> =
-    ParserPattern(operatorPatternOf(), ::operatorOutcomeOf)
+    ParserPattern(::operatorPatternOf, ::operatorOutcomeOf)
 
 private fun operatorPatternOf() = ParserSequence(
     "lhs" to generateStandardParser(),
@@ -239,7 +239,7 @@ private fun operatorOutcomeOf(values: Parsers): Expression?
  *
  */
 private fun whenParserOf(): Parser<Expression> =
-    ParserPattern(whenPatternOf(), ::whenOutcomeOf)
+    ParserPattern(::whenPatternOf, ::whenOutcomeOf)
 
 private fun whenPatternOf() = ParserSequence(
     "when" to ParserSymbol(SymbolType.WHEN),
@@ -262,7 +262,7 @@ private fun whenOutcomeOf(values: Parsers): Expression?
  *
  */
 private fun whenBranchParserOf(): Parser<Pair<Expression, Expression>> =
-    ParserPattern(whenBranchPatternOf(), ::whenBranchOutcomeOf)
+    ParserPattern(::whenBranchPatternOf, ::whenBranchOutcomeOf)
 
 private fun whenBranchPatternOf() = ParserSequence(
     "condition" to expressionParserOf(),

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
@@ -2,10 +2,7 @@ package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.core.Name
 import com.github.derg.transpiler.source.ast.*
-import com.github.derg.transpiler.source.lexeme.*
-import com.github.derg.transpiler.util.Result
-import com.github.derg.transpiler.util.failureOf
-import com.github.derg.transpiler.util.successOf
+import com.github.derg.transpiler.source.lexeme.SymbolType
 
 /**
  * Operators have a specific precedence associated with them. The higher the precedence, the later they are evaluated in
@@ -73,333 +70,209 @@ private fun mergePrefix(operator: SymbolType, rhs: Expression): Expression = whe
 }
 
 /**
+ * Joins together the [lhs] expression together with the remainder of the [terms], in a recursive manner.
+ */
+private fun mergeRecursively(lhs: Expression, terms: List<Pair<SymbolType, Expression>>, index: Int): Expression
+{
+    val (op1, mhs) = terms.getOrNull(index) ?: return lhs
+    val (op2, rhs) = terms.getOrNull(index + 1) ?: return mergeInfix(lhs, op1, mhs)
+    
+    // If next operator has higher precedence, parse left-hand of tree first
+    if (PRECEDENCE[op1]!! <= PRECEDENCE[op2]!!)
+        return mergeRecursively(mergeInfix(lhs, op1, mhs), terms, index + 1)
+    
+    // Otherwise, the remainder right-hand side must be parsed recursively
+    val rest = mergeRecursively(rhs, terms, index + 2)
+    return mergeInfix(lhs, op1, mergeInfix(mhs, op2, rest))
+}
+
+/**
  * Generates a new fresh set of the base expression parsers. The expressions do not contain the infix operator
  * expression parser, which requires special care to properly parse. It parses itself recursively in a non-trivial
  * manner.
  */
 private fun generateStandardParser(): Parser<Expression> = ParserAnyOf(
-    ParserBoolExpression(),
-    ParserRealExpression(),
-    ParserTextExpression(),
-    ParserVariableExpression(),
-    ParserFunctionExpression(),
-    ParserSubscriptExpression(),
-    ParserParenthesisExpression(),
-    ParserPrefixOperatorExpression(),
-    ParserWhenExpression(),
+    ParserBool(),
+    ParserReal(),
+    ParserText(),
+    variableCallParserOf(),
+    functionCallParserOf(),
+    subscriptCallParserOf(),
+    parenthesisParserOf(),
+    prefixOperatorParserOf(),
+    whenParserOf(),
 )
 
 /**
  * Generates a new fresh infix operator parser. The parser will only accept one of the symbols which defines one of the
  * legal infix operators.
  */
-private fun generateOperatorParser(): Parser<SymbolType> = ParserSymbol(*PRECEDENCE.keys.toTypedArray())
+private fun generateOperatorParser(): Parser<SymbolType> =
+    ParserSymbol(*PRECEDENCE.keys.toTypedArray())
 
 /**
  * Parses a single expression from the provided token.
  */
-class ParserExpression : Parser<Expression>
-{
-    private val parser = ParserRecursive { ParserOperatorExpression() }
-    
-    override fun produce(): Expression? = parser.produce()
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
-}
-
-/**
- * Parses a single boolean value from the provided token.
- */
-internal class ParserBoolExpression : Parser<Expression>
-{
-    private var expression: Expression? = null
-    
-    override fun parse(token: Token): Result<ParseOk, ParseError>
-    {
-        if (expression != null)
-            return successOf(ParseOk.Finished)
-        
-        val symbol = token as? Symbol ?: return failureOf(ParseError.UnexpectedToken(token))
-        expression = when (symbol.type)
-        {
-            SymbolType.TRUE  -> Value.Bool(true)
-            SymbolType.FALSE -> Value.Bool(false)
-            else             -> return failureOf(ParseError.UnexpectedToken(token))
-        }
-        return successOf(ParseOk.Complete)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun produce(): Expression? = expression
-    override fun reset()
-    {
-        expression = null
-    }
-}
-
-/**
- * Parses a single numeric value from the provided token.
- */
-internal class ParserRealExpression : Parser<Expression>
-{
-    private var expression: Expression? = null
-    
-    override fun parse(token: Token): Result<ParseOk, ParseError>
-    {
-        if (expression != null)
-            return successOf(ParseOk.Finished)
-        
-        val number = token as? Numeric ?: return failureOf(ParseError.UnexpectedToken(token))
-        expression = Value.Real(number.value, number.type)
-        return successOf(ParseOk.Complete)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun produce(): Expression? = expression
-    override fun reset()
-    {
-        expression = null
-    }
-}
-
-/**
- * Parses a single string value from the provided token.
- */
-internal class ParserTextExpression : Parser<Expression>
-{
-    private var expression: Expression? = null
-    
-    override fun parse(token: Token): Result<ParseOk, ParseError>
-    {
-        if (expression != null)
-            return successOf(ParseOk.Finished)
-        
-        val string = token as? Textual ?: return failureOf(ParseError.UnexpectedToken(token))
-        expression = Value.Text(string.value, string.type)
-        return successOf(ParseOk.Complete)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun produce(): Expression? = expression
-    override fun reset()
-    {
-        expression = null
-    }
-}
+fun expressionParserOf(): Parser<Expression> =
+    ParserPattern(ParserRecursive { operatorParserOf() }) { it }
 
 /**
  * Parses a variable access expression from the provided token.
  */
-internal class ParserVariableExpression : Parser<Expression>
-{
-    private val parser = ParserName()
-    
-    override fun skipable(): Boolean = false
-    override fun produce(): Expression? = parser.produce()?.let { Access.Variable(it) }
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
-}
+private fun variableCallParserOf(): Parser<Expression> =
+    ParserPattern(ParserName()) { Access.Variable(it) }
 
 /**
  * Parses a function call expression from the provided token.
  */
-internal class ParserFunctionExpression : Parser<Expression>
+internal fun functionCallParserOf(): Parser<Expression> =
+    ParserPattern(functionCallPatternOf(), ::functionCallOutcomeOf)
+
+private fun functionCallPatternOf() = ParserSequence(
+    "name" to ParserName(),
+    "open" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
+    "params" to ParserOptional(ParserRepeating(parameterParserOf(), ParserSymbol(SymbolType.COMMA))),
+    "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
+)
+
+private fun functionCallOutcomeOf(outcome: Parsers): Expression?
 {
-    private val parser = ParserSequence(
-        "name" to ParserName(),
-        "open" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
-        "params" to ParserOptional(ParserRepeating(ParserParameter(), ParserSymbol(SymbolType.COMMA))),
-        "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
-    )
-    
-    override fun produce(): Expression?
-    {
-        val values = parser.produce()
-        val name = values.produce<Name>("name") ?: return null
-        val params = values.produce<List<Parameter>>("params") ?: emptyList()
-        return Access.Function(name, params)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val name = outcome.produce<Name>("name") ?: return null
+    val params = outcome.produce<List<Parameter>>("params") ?: emptyList()
+    return Access.Function(name, params)
 }
 
 /**
  * Parses a subscript call expression from the provided token.
  */
-internal class ParserSubscriptExpression : Parser<Expression>
+private fun subscriptCallParserOf(): Parser<Expression> =
+    ParserPattern(subscriptCallPatternOf(), ::subscriptCallOutcomeOf)
+
+private fun subscriptCallPatternOf() = ParserSequence(
+    "name" to ParserName(),
+    "open" to ParserSymbol(SymbolType.OPEN_BRACKET),
+    "params" to ParserOptional(ParserRepeating(parameterParserOf(), ParserSymbol(SymbolType.COMMA))),
+    "close" to ParserSymbol(SymbolType.CLOSE_BRACKET),
+)
+
+private fun subscriptCallOutcomeOf(values: Parsers): Expression?
 {
-    private val parser = ParserSequence(
-        "name" to ParserName(),
-        "open" to ParserSymbol(SymbolType.OPEN_BRACKET),
-        "params" to ParserOptional(ParserRepeating(ParserParameter(), ParserSymbol(SymbolType.COMMA))),
-        "close" to ParserSymbol(SymbolType.CLOSE_BRACKET),
-    )
-    
-    override fun produce(): Expression?
-    {
-        val values = parser.produce()
-        val name = values.produce<Name>("name") ?: return null
-        val params = values.produce<List<Parameter>>("params") ?: emptyList()
-        return Access.Subscript(name, params)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val name = values.produce<Name>("name") ?: return null
+    val params = values.produce<List<Parameter>>("params") ?: emptyList()
+    return Access.Subscript(name, params)
 }
 
 /**
  * Parses a function call parameter from the provided token.
  */
-private class ParserParameter : Parser<Parameter>
+private fun parameterParserOf(): Parser<Parameter> =
+    ParserPattern(parameterPatternOf(), ::parameterOutcomeOf)
+
+private fun parameterPatternOf() = ParserAnyOf(
+    ParserSequence("expr" to expressionParserOf()),
+    ParserSequence("name" to ParserName(), "sym" to ParserSymbol(SymbolType.ASSIGN), "expr" to expressionParserOf()),
+)
+
+private fun parameterOutcomeOf(values: Parsers): Parameter?
 {
-    // Note: cannot use optional parser to extract the name, as an identifier is also a legal name. This can cause the
-    //       optional parser to fail on missing equals symbol, when the developer intended to pass a regular variable as
-    //       a parameter to a function.
-    private val parser = ParserAnyOf(
-        ParserSequence("name" to ParserName(), "sym" to ParserSymbol(SymbolType.ASSIGN), "expr" to ParserExpression()),
-        ParserSequence("expr" to ParserExpression()),
-    )
-    
-    override fun produce(): Parameter?
-    {
-        val values = parser.produce() ?: return null
-        val name = values.produce<Name>("name")
-        val expression = values.produce<Expression>("expr") ?: return null
-        return Parameter(name, expression)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val name = values.produce<Name>("name")
+    val expression = values.produce<Expression>("expr") ?: return null
+    return Parameter(name, expression)
 }
 
 /**
  * Parses an expression from in-between parenthesis from the provided token.
  */
-private class ParserParenthesisExpression : Parser<Expression>
-{
-    private val parser = ParserSequence(
-        "open" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
-        "expr" to ParserRecursive { ParserOperatorExpression() },
-        "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
-    )
-    
-    override fun skipable(): Boolean = false
-    override fun produce(): Expression? = parser.produce().produce("expr")
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
-}
+private fun parenthesisParserOf(): Parser<Expression> =
+    ParserPattern(parenthesisPatternOf(), ::parenthesisOutcomeOf)
+
+private fun parenthesisPatternOf() = ParserSequence(
+    "open" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
+    "expr" to ParserRecursive { operatorParserOf() },
+    "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
+)
+
+private fun parenthesisOutcomeOf(values: Parsers): Expression? =
+    values.produce("expr")
 
 /**
  * Parses an operator from the provided token. Prefix operators are non-trivial to construct, and involves recursively
  * parsing the stream of tokens.
  */
-private class ParserPrefixOperatorExpression : Parser<Expression>
+private fun prefixOperatorParserOf(): Parser<Expression> =
+    ParserPattern(prefixOperatorPatternOf(), ::prefixOperatorOutcomeOf)
+
+private fun prefixOperatorPatternOf() = ParserSequence(
+    "op" to ParserSymbol(SymbolType.PLUS, SymbolType.MINUS, SymbolType.NOT),
+    "rhs" to ParserRecursive { generateStandardParser() },
+)
+
+private fun prefixOperatorOutcomeOf(values: Parsers): Expression?
 {
-    private val parser = ParserSequence(
-        "op" to ParserSymbol(SymbolType.PLUS, SymbolType.MINUS, SymbolType.NOT),
-        "rhs" to ParserRecursive { generateStandardParser() },
-    )
-    
-    override fun produce(): Expression?
-    {
-        val values = parser.produce()
-        val op = values.produce<SymbolType>("op") ?: return null
-        val rhs = values.produce<Expression>("rhs") ?: return null
-        return mergePrefix(op, rhs)
-    }
-    
-    override fun skipable(): Boolean = parser.skipable()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val op = values.produce<SymbolType>("op") ?: return null
+    val rhs = values.produce<Expression>("rhs") ?: return null
+    return mergePrefix(op, rhs)
 }
 
 /**
  * Parses an operator from the provided token. Operators are non-trivial to construct, and parsing of them depends on
  * the type of operator, as well as the precedence.
  */
-private class ParserOperatorExpression : Parser<Expression>
+private fun operatorParserOf(): Parser<Expression> =
+    ParserPattern(operatorPatternOf(), ::operatorOutcomeOf)
+
+private fun operatorPatternOf() = ParserSequence(
+    "lhs" to generateStandardParser(),
+    "terms" to ParserRepeating(ParserSequence("op" to generateOperatorParser(), "rhs" to generateStandardParser())),
+)
+
+private fun operatorOutcomeOf(values: Parsers): Expression?
 {
-    private val parser = ParserSequence(
-        "lhs" to generateStandardParser(),
-        "terms" to ParserRepeating(ParserSequence("op" to generateOperatorParser(), "rhs" to generateStandardParser())),
-    )
-    
-    private fun combineRecursively(lhs: Expression, terms: List<Pair<SymbolType, Expression>>, index: Int): Expression
-    {
-        val (op1, mhs) = terms.getOrNull(index) ?: return lhs
-        val (op2, rhs) = terms.getOrNull(index + 1) ?: return mergeInfix(lhs, op1, mhs)
-        
-        // If next operator has higher precedence, parse left-hand of tree first
-        if (PRECEDENCE[op1]!! <= PRECEDENCE[op2]!!)
-            return combineRecursively(mergeInfix(lhs, op1, mhs), terms, index + 1)
-        
-        // Otherwise, the remainder right-hand side must be parsed recursively
-        val rest = combineRecursively(rhs, terms, index + 2)
-        return mergeInfix(lhs, op1, mergeInfix(mhs, op2, rest))
-    }
-    
-    override fun produce(): Expression?
-    {
-        val values = parser.produce()
-        val lhs = values.produce<Expression>("lhs") ?: return null
-        val terms = values.produce<List<Parsers>>("terms") ?: emptyList()
-        val ops = terms.produce<SymbolType>("op")
-        val rhs = terms.produce<Expression>("rhs")
-        return combineRecursively(lhs, ops.zip(rhs), 0)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val lhs = values.produce<Expression>("lhs") ?: return null
+    val terms = values.produce<List<Parsers>>("terms") ?: emptyList()
+    val ops = terms.produce<SymbolType>("op")
+    val rhs = terms.produce<Expression>("rhs")
+    return mergeRecursively(lhs, ops.zip(rhs), 0)
 }
 
-private class ParserWhenExpression : Parser<Expression>
+/**
+ *
+ */
+private fun whenParserOf(): Parser<Expression> =
+    ParserPattern(whenPatternOf(), ::whenOutcomeOf)
+
+private fun whenPatternOf() = ParserSequence(
+    "when" to ParserSymbol(SymbolType.WHEN),
+    "expression" to expressionParserOf(),
+    "first" to whenBranchParserOf(),
+    "remainder" to ParserRepeating(whenBranchParserOf()),
+    "else" to ParserOptional(ParserSequence("else" to ParserSymbol(SymbolType.ELSE), "expr" to expressionParserOf())),
+)
+
+private fun whenOutcomeOf(values: Parsers): Expression?
 {
-    private val parser = ParserSequence(
-        "when" to ParserSymbol(SymbolType.WHEN),
-        "expression" to ParserExpression(),
-        "first" to ParserWhenBranch(),
-        "remainder" to ParserRepeating(ParserWhenBranch()),
-        "else" to ParserOptional(ParserSequence("else" to ParserSymbol(SymbolType.ELSE), "expr" to ParserExpression())),
-    )
-    
-    override fun produce(): Expression?
-    {
-        val values = parser.produce()
-        val expression = values.produce<Expression>("expression") ?: return null
-        val default = values.produce<Parsers>("else")?.produce<Expression>("expr")
-        val first = listOf(values.produce<Pair<Expression, Expression>>("first") ?: return null)
-        val branches = values.produce<List<Pair<Expression, Expression>>>("remainder") ?: return null
-        return When(expression, first + branches, default)
-    }
-    
-    override fun skipable(): Boolean = parser.skipable()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val expression = values.produce<Expression>("expression") ?: return null
+    val default = values.produce<Parsers>("else")?.produce<Expression>("expr")
+    val first = listOf(values.produce<Pair<Expression, Expression>>("first") ?: return null)
+    val branches = values.produce<List<Pair<Expression, Expression>>>("remainder") ?: return null
+    return When(expression, first + branches, default)
 }
 
-private class ParserWhenBranch : Parser<Pair<Expression, Expression>>
+/**
+ *
+ */
+private fun whenBranchParserOf(): Parser<Pair<Expression, Expression>> =
+    ParserPattern(whenBranchPatternOf(), ::whenBranchOutcomeOf)
+
+private fun whenBranchPatternOf() = ParserSequence(
+    "condition" to expressionParserOf(),
+    "separator" to ParserSymbol(SymbolType.ARROW),
+    "expression" to expressionParserOf(),
+)
+
+private fun whenBranchOutcomeOf(values: Parsers): Pair<Expression, Expression>?
 {
-    private val parser = ParserSequence(
-        "condition" to ParserExpression(),
-        "separator" to ParserSymbol(SymbolType.ARROW),
-        "expression" to ParserExpression(),
-    )
-    
-    override fun produce(): Pair<Expression, Expression>?
-    {
-        val values = parser.produce()
-        val cond = values.produce<Expression>("condition") ?: return null
-        val expr = values.produce<Expression>("expression") ?: return null
-        return cond to expr
-    }
-    
-    override fun skipable(): Boolean = parser.skipable()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val cond = values.produce<Expression>("condition") ?: return null
+    val expr = values.produce<Expression>("expression") ?: return null
+    return cond to expr
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -19,10 +19,12 @@ private fun merge(name: Name, operator: SymbolType, rhs: Expression): Assignment
 }
 
 /**
- * Generates a new fresh set of the base statements parsers. This generator parses recursively, where sub-parsers may
- * require parsing additional statements.
+ * Parses a single statement from the token stream.
  */
-private fun generateStandardParser(): Parser<Statement> = ParserAnyOf(
+fun statementParserOf(): Parser<Statement> =
+    ParserPattern(::statementPatternOf) { it }
+
+private fun statementPatternOf(): Parser<Statement> = ParserAnyOf(
     variableParserOf(),
     functionParserOf(),
     assignmentParserOf(),
@@ -33,13 +35,7 @@ private fun generateStandardParser(): Parser<Statement> = ParserAnyOf(
 )
 
 /**
- * Parses a single statement from the provided token.
- */
-fun statementParserOf(): Parser<Statement> =
-    ParserPattern(::generateStandardParser) { it }
-
-/**
- * Parses a single scope from the provided token.
+ * Parses a single scope from the token stream.
  */
 fun scopeParserOf(): Parser<Scope> =
     ParserPattern(::scopePatternOf, ::scopeOutcomeOf)
@@ -62,7 +58,7 @@ private fun scopeOutcomeOf(values: Parsers): Scope?
 }
 
 /**
- * Parses a single assignment from the provided token.
+ * Parses a single assignment from the token stream.
  */
 private fun assignmentParserOf(): Parser<Statement> =
     ParserPattern(::assignmentPatternOf, ::assignmentOutcomeOf)
@@ -89,7 +85,7 @@ private fun assignmentOutcomeOf(values: Parsers): Assignment?
 }
 
 /**
- * Parses a single branch control from the provided token.
+ * Parses a single branch control from the token stream.
  */
 private fun branchParserOf(): Parser<Statement> =
     ParserPattern(::branchPatternOf, ::branchOutcomeOf)
@@ -110,7 +106,7 @@ private fun branchOutcomeOf(values: Parsers): Control.Branch?
 }
 
 /**
- * Parses a single raise control flow from the provided token.
+ * Parses a single raise control flow from the token stream.
  */
 private fun raiseParserOf(): Parser<Statement> =
     ParserPattern(::raisePatternOf, ::raiseOutcomeOf)
@@ -127,7 +123,7 @@ private fun raiseOutcomeOf(values: Parsers): Control.Raise?
 }
 
 /**
- * Parses a single return control flow from the provided token.
+ * Parses a single return control flow from the token stream.
  */
 private fun returnParserOf(): Parser<Statement> =
     ParserPattern(::returnPatternOf, ::returnOutcomeOf)
@@ -145,7 +141,7 @@ private fun returnOutcomeOf(values: Parsers): Control.Return?
 }
 
 /**
- * Parses a single expression statement from the provided token. Note that the parser does not implement analysis to
+ * Parses a single expression statement from the token stream. Note that the parser does not implement analysis to
  * determine whether the expression has any value or error types.
  */
 // TODO: Not a correct implementation of the parser - must also function with error handling

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -3,8 +3,6 @@ package com.github.derg.transpiler.phases.parser
 import com.github.derg.transpiler.core.Name
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.lexeme.SymbolType
-import com.github.derg.transpiler.source.lexeme.Token
-import com.github.derg.transpiler.util.Result
 
 /**
  * Joins together the [name] with the [operator] and the [rhs] expression.
@@ -25,171 +23,131 @@ private fun merge(name: Name, operator: SymbolType, rhs: Expression): Assignment
  * require parsing additional statements.
  */
 private fun generateStandardParser(): Parser<Statement> = ParserAnyOf(
-    ParserVariableDefinition(),
-    ParserFunctionDefinition(),
-    ParserAssignment(),
-    ParserBranch(),
-    ParserCall(),
-    ParserRaise(),
-    ParserReturn(),
+    variableParserOf(),
+    functionParserOf(),
+    assignmentParserOf(),
+    branchParserOf(),
+    callParserOf(),
+    raiseParserOf(),
+    returnParserOf(),
 )
 
 /**
  * Parses a single statement from the provided token.
  */
-class ParserStatement : Parser<Statement>
-{
-    private val parser = ParserRecursive { generateStandardParser() }
-    
-    override fun produce(): Statement? = parser.produce()
-    override fun skipable(): Boolean = parser.skipable()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
-}
+fun statementParserOf(): Parser<Statement> =
+    ParserPattern(ParserRecursive(::generateStandardParser)) { it }
 
 /**
  * Parses a single scope from the provided token.
  */
-class ParserScope : Parser<Scope>
+fun scopeParserOf(): Parser<Scope> =
+    ParserPattern(ParserRecursive(::scopePatternOf), ::scopeOutcomeOf)
+
+private fun scopePatternOf() = ParserAnyOf(
+    ParserSequence("single" to statementParserOf()),
+    ParserSequence(
+        "open" to ParserSymbol(SymbolType.OPEN_BRACE),
+        "multiple" to ParserRepeating(statementParserOf()),
+        "close" to ParserSymbol(SymbolType.CLOSE_BRACE),
+    )
+)
+
+private fun scopeOutcomeOf(values: Parsers): Scope?
 {
-    private val parser = ParserRecursive()
-    {
-        ParserAnyOf(
-            ParserSequence("single" to ParserStatement()),
-            ParserSequence(
-                "open" to ParserSymbol(SymbolType.OPEN_BRACE),
-                "multiple" to ParserRepeating(ParserStatement()),
-                "close" to ParserSymbol(SymbolType.CLOSE_BRACE),
-            )
-        )
-    }
-    
-    override fun produce(): Scope?
-    {
-        val values = parser.produce() ?: return null
-        val statement = values.produce<Statement>("single")
-        val statements = values.produce<List<Statement>>("multiple")
-        val isBraced = statement == null
-        return Scope(isBraced, statements ?: statement?.let { listOf(it) } ?: return null)
-    }
-    
-    override fun skipable(): Boolean = parser.skipable()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val statement = values.produce<Statement>("single")
+    val statements = values.produce<List<Statement>>("multiple")
+    val isBraced = statement == null
+    return Scope(isBraced, statements ?: statement?.let { listOf(it) } ?: return null)
 }
 
 /**
  * Parses a single assignment from the provided token.
  */
-private class ParserAssignment : Parser<Statement>
+private fun assignmentParserOf(): Parser<Statement> =
+    ParserPattern(assignmentPatternOf(), ::assignmentOutcomeOf)
+
+private fun assignmentPatternOf() = ParserSequence(
+    "name" to ParserName(),
+    "op" to ParserSymbol(
+        SymbolType.ASSIGN,
+        SymbolType.ASSIGN_PLUS,
+        SymbolType.ASSIGN_MINUS,
+        SymbolType.ASSIGN_MULTIPLY,
+        SymbolType.ASSIGN_DIVIDE,
+        SymbolType.ASSIGN_MODULO,
+    ),
+    "rhs" to expressionParserOf(),
+)
+
+private fun assignmentOutcomeOf(values: Parsers): Assignment?
 {
-    private val parser = ParserSequence(
-        "name" to ParserName(),
-        "op" to ParserSymbol(
-            SymbolType.ASSIGN,
-            SymbolType.ASSIGN_PLUS,
-            SymbolType.ASSIGN_MINUS,
-            SymbolType.ASSIGN_MULTIPLY,
-            SymbolType.ASSIGN_DIVIDE,
-            SymbolType.ASSIGN_MODULO,
-        ),
-        "rhs" to ParserExpression(),
-    )
-    
-    override fun produce(): Statement?
-    {
-        val values = parser.produce()
-        val name = values.produce<Name>("name") ?: return null
-        val op = values.produce<SymbolType>("op") ?: return null
-        val rhs = values.produce<Expression>("rhs") ?: return null
-        return merge(name, op, rhs)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val name = values.produce<Name>("name") ?: return null
+    val op = values.produce<SymbolType>("op") ?: return null
+    val rhs = values.produce<Expression>("rhs") ?: return null
+    return merge(name, op, rhs)
 }
 
 /**
  * Parses a single branch control from the provided token.
  */
-private class ParserBranch : Parser<Statement>
+private fun branchParserOf(): Parser<Statement> =
+    ParserPattern(branchPatternOf(), ::branchOutcomeOf)
+
+private fun branchPatternOf() = ParserSequence(
+    "if" to ParserSymbol(SymbolType.IF),
+    "predicate" to expressionParserOf(),
+    "success" to scopeParserOf(),
+    "other" to ParserOptional(ParserSequence("else" to ParserSymbol(SymbolType.ELSE), "failure" to scopeParserOf())),
+)
+
+private fun branchOutcomeOf(values: Parsers): Control.Branch?
 {
-    private val parser = ParserSequence(
-        "if" to ParserSymbol(SymbolType.IF),
-        "predicate" to ParserExpression(),
-        "success" to ParserScope(),
-        "other" to ParserOptional(ParserSequence("else" to ParserSymbol(SymbolType.ELSE), "failure" to ParserScope())),
-    )
-    
-    override fun produce(): Statement?
-    {
-        val values = parser.produce()
-        val predicate = values.produce<Expression>("predicate") ?: return null
-        val success = values.produce<Scope>("success") ?: return null
-        val failure = values.produce<Parsers>("other")?.produce<Scope>("failure")
-        return Control.Branch(predicate, success, failure)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val predicate = values.produce<Expression>("predicate") ?: return null
+    val success = values.produce<Scope>("success") ?: return null
+    val failure = values.produce<Parsers>("other")?.produce<Scope>("failure")
+    return Control.Branch(predicate, success, failure)
 }
 
 /**
  * Parses a single raise control flow from the provided token.
  */
-private class ParserRaise : Parser<Statement>
+private fun raiseParserOf(): Parser<Statement> =
+    ParserPattern(raisePatternOf(), ::raiseOutcomeOf)
+
+private fun raisePatternOf() = ParserSequence(
+    "symbol" to ParserSymbol(SymbolType.RETURN_ERROR),
+    "expression" to expressionParserOf(),
+)
+
+private fun raiseOutcomeOf(values: Parsers): Control.Raise?
 {
-    private val parser = ParserSequence(
-        "raise" to ParserSymbol(SymbolType.RETURN_ERROR),
-        "expression" to ParserExpression(),
-    )
-    
-    override fun produce(): Statement?
-    {
-        val expression = parser.produce().produce<Expression>("expression") ?: return null
-        return Control.Raise(expression)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val expression = values.produce<Expression>("expression") ?: return null
+    return Control.Raise(expression)
 }
 
 /**
  * Parses a single return control flow from the provided token.
  */
-private class ParserReturn : Parser<Statement>
+private fun returnParserOf(): Parser<Statement> =
+    ParserPattern(returnPatternOf(), ::returnOutcomeOf)
+
+private fun returnPatternOf() = ParserSequence(
+    "symbol" to ParserSymbol(SymbolType.RETURN_VALUE),
+    "expression" to expressionParserOf(),
+)
+
+private fun returnOutcomeOf(values: Parsers): Control.Return?
 {
-    private val parser = ParserSequence(
-        "raise" to ParserSymbol(SymbolType.RETURN_VALUE),
-        "expression" to ParserExpression(),
-    )
-    
-    override fun produce(): Statement
-    {
-        val expression = parser.produce().produce<Expression>("expression")
-        // TODO: The magic string `_` should not be used. Use the type-information of the function to remove it
-        return if (expression == Access.Variable("_")) Control.Return(null) else Control.Return(expression)
-    }
-    
-    override fun skipable(): Boolean = false
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
+    val expression = values.produce<Expression>("expression") ?: return null
+    // TODO: The magic string `_` should not be used. Use the type-information of the function to remove it
+    return if (expression == Access.Variable("_")) Control.Return(null) else Control.Return(expression)
 }
 
 /**
  * Parses a single expression statement from the provided token. Note that the parser does not implement analysis to
  * determine whether the expression has any value or error types.
  */
-private class ParserCall : Parser<Statement>
-{
-    // TODO: Not a correct implementation of the parser - must also function with error handling
-    private val parser = ParserFunctionExpression()
-    
-    override fun produce(): Statement? = parser.produce()?.let { Control.Call(it) }
-    override fun skipable(): Boolean = parser.skipable()
-    override fun parse(token: Token): Result<ParseOk, ParseError> = parser.parse(token)
-    override fun reset() = parser.reset()
-}
+// TODO: Not a correct implementation of the parser - must also function with error handling
+private fun callParserOf(): Parser<Statement> =
+    ParserPattern(functionCallParserOf()) { Control.Call(it) }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -36,13 +36,13 @@ private fun generateStandardParser(): Parser<Statement> = ParserAnyOf(
  * Parses a single statement from the provided token.
  */
 fun statementParserOf(): Parser<Statement> =
-    ParserPattern(ParserRecursive(::generateStandardParser)) { it }
+    ParserPattern(::generateStandardParser) { it }
 
 /**
  * Parses a single scope from the provided token.
  */
 fun scopeParserOf(): Parser<Scope> =
-    ParserPattern(ParserRecursive(::scopePatternOf), ::scopeOutcomeOf)
+    ParserPattern(::scopePatternOf, ::scopeOutcomeOf)
 
 private fun scopePatternOf() = ParserAnyOf(
     ParserSequence("single" to statementParserOf()),
@@ -65,7 +65,7 @@ private fun scopeOutcomeOf(values: Parsers): Scope?
  * Parses a single assignment from the provided token.
  */
 private fun assignmentParserOf(): Parser<Statement> =
-    ParserPattern(assignmentPatternOf(), ::assignmentOutcomeOf)
+    ParserPattern(::assignmentPatternOf, ::assignmentOutcomeOf)
 
 private fun assignmentPatternOf() = ParserSequence(
     "name" to ParserName(),
@@ -92,7 +92,7 @@ private fun assignmentOutcomeOf(values: Parsers): Assignment?
  * Parses a single branch control from the provided token.
  */
 private fun branchParserOf(): Parser<Statement> =
-    ParserPattern(branchPatternOf(), ::branchOutcomeOf)
+    ParserPattern(::branchPatternOf, ::branchOutcomeOf)
 
 private fun branchPatternOf() = ParserSequence(
     "if" to ParserSymbol(SymbolType.IF),
@@ -113,7 +113,7 @@ private fun branchOutcomeOf(values: Parsers): Control.Branch?
  * Parses a single raise control flow from the provided token.
  */
 private fun raiseParserOf(): Parser<Statement> =
-    ParserPattern(raisePatternOf(), ::raiseOutcomeOf)
+    ParserPattern(::raisePatternOf, ::raiseOutcomeOf)
 
 private fun raisePatternOf() = ParserSequence(
     "symbol" to ParserSymbol(SymbolType.RETURN_ERROR),
@@ -130,7 +130,7 @@ private fun raiseOutcomeOf(values: Parsers): Control.Raise?
  * Parses a single return control flow from the provided token.
  */
 private fun returnParserOf(): Parser<Statement> =
-    ParserPattern(returnPatternOf(), ::returnOutcomeOf)
+    ParserPattern(::returnPatternOf, ::returnOutcomeOf)
 
 private fun returnPatternOf() = ParserSequence(
     "symbol" to ParserSymbol(SymbolType.RETURN_VALUE),
@@ -150,4 +150,4 @@ private fun returnOutcomeOf(values: Parsers): Control.Return?
  */
 // TODO: Not a correct implementation of the parser - must also function with error handling
 private fun callParserOf(): Parser<Statement> =
-    ParserPattern(functionCallParserOf()) { Control.Call(it) }
+    ParserPattern(::functionCallParserOf) { Control.Call(it) }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
@@ -1,10 +1,9 @@
 package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.core.Name
-import com.github.derg.transpiler.source.lexeme.Identifier
-import com.github.derg.transpiler.source.lexeme.Symbol
-import com.github.derg.transpiler.source.lexeme.SymbolType
-import com.github.derg.transpiler.source.lexeme.Token
+import com.github.derg.transpiler.source.ast.Expression
+import com.github.derg.transpiler.source.ast.Value
+import com.github.derg.transpiler.source.lexeme.*
 import com.github.derg.transpiler.util.Result
 import com.github.derg.transpiler.util.failureOf
 import com.github.derg.transpiler.util.successOf
@@ -58,5 +57,85 @@ class ParserSymbol(vararg symbols: SymbolType) : Parser<SymbolType>
     override fun reset()
     {
         type = null
+    }
+}
+
+/**
+ * Parses a single boolean value from the provided token.
+ */
+class ParserBool : Parser<Expression>
+{
+    private var expression: Expression? = null
+    
+    override fun parse(token: Token): Result<ParseOk, ParseError>
+    {
+        if (expression != null)
+            return successOf(ParseOk.Finished)
+        
+        val symbol = token as? Symbol ?: return failureOf(ParseError.UnexpectedToken(token))
+        expression = when (symbol.type)
+        {
+            SymbolType.TRUE  -> Value.Bool(true)
+            SymbolType.FALSE -> Value.Bool(false)
+            else             -> return failureOf(ParseError.UnexpectedToken(token))
+        }
+        return successOf(ParseOk.Complete)
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun produce(): Expression? = expression
+    override fun reset()
+    {
+        expression = null
+    }
+}
+
+/**
+ * Parses a single numeric value from the provided token.
+ */
+class ParserReal : Parser<Expression>
+{
+    private var expression: Expression? = null
+    
+    override fun parse(token: Token): Result<ParseOk, ParseError>
+    {
+        if (expression != null)
+            return successOf(ParseOk.Finished)
+        
+        val number = token as? Numeric ?: return failureOf(ParseError.UnexpectedToken(token))
+        expression = Value.Real(number.value, number.type)
+        return successOf(ParseOk.Complete)
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun produce(): Expression? = expression
+    override fun reset()
+    {
+        expression = null
+    }
+}
+
+/**
+ * Parses a single string value from the provided token.
+ */
+class ParserText : Parser<Expression>
+{
+    private var expression: Expression? = null
+    
+    override fun parse(token: Token): Result<ParseOk, ParseError>
+    {
+        if (expression != null)
+            return successOf(ParseOk.Finished)
+        
+        val string = token as? Textual ?: return failureOf(ParseError.UnexpectedToken(token))
+        expression = Value.Text(string.value, string.type)
+        return successOf(ParseOk.Complete)
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun produce(): Expression? = expression
+    override fun reset()
+    {
+        expression = null
     }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
@@ -9,7 +9,7 @@ import com.github.derg.transpiler.util.failureOf
 import com.github.derg.transpiler.util.successOf
 
 /**
- * Parses a single identifier from the provided token.
+ * Parses a single identifier from the token stream.
  */
 class ParserName : Parser<Name>
 {
@@ -34,7 +34,7 @@ class ParserName : Parser<Name>
 }
 
 /**
- * Parses a single symbol from the provided token. The parser will only accept one of the symbols present in the
+ * Parses a single symbol from the token stream. The parser will only accept one of the symbols present in the
  * [whitelist] when parsing. Any symbol not found in the whitelist is treated as an unexpected token.
  */
 class ParserSymbol(vararg symbols: SymbolType) : Parser<SymbolType>
@@ -61,7 +61,7 @@ class ParserSymbol(vararg symbols: SymbolType) : Parser<SymbolType>
 }
 
 /**
- * Parses a single boolean value from the provided token.
+ * Parses a single boolean value from the token stream.
  */
 class ParserBool : Parser<Expression>
 {
@@ -91,7 +91,7 @@ class ParserBool : Parser<Expression>
 }
 
 /**
- * Parses a single numeric value from the provided token.
+ * Parses a single numeric value from the token stream.
  */
 class ParserReal : Parser<Expression>
 {
@@ -116,7 +116,7 @@ class ParserReal : Parser<Expression>
 }
 
 /**
- * Parses a single string value from the provided token.
+ * Parses a single string value from the token stream.
  */
 class ParserText : Parser<Expression>
 {

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/Helpers.kt
@@ -153,14 +153,14 @@ fun scopeOf(isBraced: Boolean, vararg statements: Statement) =
     Scope(isBraced, statements.toList())
 
 /**
- * To simplify testing of the parsing of source code for any particular pattern [factory], a helper class is provided.
+ * To simplify testing of the parsing of source code for any particular pattern factory, a helper class is provided.
  * This tester class allows the developer to write clearer and more concise test cases when parsing specific source
  * code. Each source code snippet can be tailor-made to suit certain edge-cases.
  */
-class Tester<Type>(private val factory: () -> Parser<Type>)
+class Tester<Type>(factory: () -> Parser<Type>)
 {
-    internal lateinit var parser: Parser<Type>
-    private lateinit var tokens: List<Token>
+    internal val parser: Parser<Type> = factory()
+    private var tokens: List<Token> = emptyList()
     private var cursor: Int = 0
     
     /**
@@ -168,7 +168,7 @@ class Tester<Type>(private val factory: () -> Parser<Type>)
      */
     fun parse(source: String): Tester<Type>
     {
-        parser = factory()
+        parser.reset()
         tokens = tokenize(source).map { it.data }
         cursor = 0
         return this

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
@@ -278,7 +278,7 @@ class TestParserOptional
 
 class TestParserPattern
 {
-    private val pattern = ParserSequence(
+    private fun pattern() = ParserSequence(
         "lhs" to ParserReal(),
         "rhs" to ParserReal(),
     )
@@ -293,7 +293,7 @@ class TestParserPattern
     @Test
     fun `Given valid token, when parsing simple, then value produced`()
     {
-        val tester = Tester { ParserPattern(pattern, ::converter) }
+        val tester = Tester { ParserPattern(::pattern, ::converter) }
         
         tester.parse("1 2").isWip(1).isOk(1).isDone().isValue(1 opAdd 2).resets()
     }
@@ -301,7 +301,7 @@ class TestParserPattern
     @Test
     fun `Given invalid token, when parsing simple, then correct error`()
     {
-        val tester = Tester { ParserPattern(pattern, ::converter) }
+        val tester = Tester { ParserPattern(::pattern, ::converter) }
         
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("1").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
@@ -26,7 +26,7 @@ class TestParserAnyOf
     @Test
     fun `Given valid token, when parsing simple, then value produced`()
     {
-        val tester = Tester { ParserAnyOf(ParserRealExpression(), ParserBoolExpression()) }
+        val tester = Tester { ParserAnyOf(ParserReal(), ParserBool()) }
         
         tester.parse("42").isOk(1).isDone().isValue(42.toExp()).resets()
         tester.parse("true").isOk(1).isDone().isValue(true.toExp()).resets()
@@ -38,9 +38,9 @@ class TestParserAnyOf
         val tester = Tester()
         {
             ParserAnyOf(
-                ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression()),
-                ParserSequence(TEXT to ParserTextExpression(), BOOL to ParserBoolExpression()),
-                ParserSequence(TEXT to ParserTextExpression()),
+                ParserSequence(REAL to ParserReal(), BOOL to ParserBool()),
+                ParserSequence(TEXT to ParserText(), BOOL to ParserBool()),
+                ParserSequence(TEXT to ParserText()),
             )
         }
         
@@ -55,7 +55,7 @@ class TestParserAnyOf
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        val tester = Tester { ParserAnyOf(ParserRealExpression(), ParserBoolExpression()) }
+        val tester = Tester { ParserAnyOf(ParserReal(), ParserBool()) }
         
         tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
     }
@@ -74,7 +74,7 @@ class TestParserAllOf
     @Test
     fun `Given valid token, when parsing simple, then value produced`()
     {
-        val tester = Tester { ParserAllOf(REAL to ParserRealExpression(), BOOL to ParserBoolExpression()) }
+        val tester = Tester { ParserAllOf(REAL to ParserReal(), BOOL to ParserBool()) }
         
         tester.parse("42 true").isWip(1).isOk(1).isDone()
             .hasValue(REAL, 42.toExp()).hasValue(BOOL, true.toExp())
@@ -88,9 +88,9 @@ class TestParserAllOf
         val tester = Tester()
         {
             ParserAllOf(
-                REAL to ParserSequence("a" to ParserRealExpression(), "b" to ParserRealExpression()),
-                BOOL to ParserBoolExpression(),
-                TEXT to ParserOptional(ParserTextExpression()),
+                REAL to ParserSequence("a" to ParserReal(), "b" to ParserReal()),
+                BOOL to ParserBool(),
+                TEXT to ParserOptional(ParserText()),
             )
         }
         
@@ -106,7 +106,7 @@ class TestParserAllOf
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        val tester = Tester { ParserAllOf(REAL to ParserRealExpression(), BOOL to ParserBoolExpression()) }
+        val tester = Tester { ParserAllOf(REAL to ParserReal(), BOOL to ParserBool()) }
         
         tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
         tester.parse("42").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
@@ -130,9 +130,9 @@ class TestParserSequence
         val tester = Tester()
         {
             ParserSequence(
-                REAL to ParserRealExpression(),
-                BOOL to ParserBoolExpression(),
-                TEXT to ParserTextExpression(),
+                REAL to ParserReal(),
+                BOOL to ParserBool(),
+                TEXT to ParserText(),
             )
         }
         
@@ -146,9 +146,9 @@ class TestParserSequence
         val tester = Tester()
         {
             ParserSequence(
-                REAL to ParserSequence("a" to ParserRealExpression(), "b" to ParserRealExpression()),
-                BOOL to ParserSequence("a" to ParserBoolExpression(), "b" to ParserBoolExpression()),
-                TEXT to ParserOptional(ParserTextExpression()),
+                REAL to ParserSequence("a" to ParserReal(), "b" to ParserReal()),
+                BOOL to ParserSequence("a" to ParserBool(), "b" to ParserBool()),
+                TEXT to ParserOptional(ParserText()),
             )
         }
         
@@ -160,7 +160,7 @@ class TestParserSequence
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        val tester = Tester { ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression()) }
+        val tester = Tester { ParserSequence(REAL to ParserReal(), BOOL to ParserBool()) }
         
         tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
         tester.parse("1").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
@@ -172,7 +172,7 @@ class TestParserRepeating
     @Test
     fun `Given valid token, when parsing simple, then value produced`()
     {
-        val tester = Tester { ParserRepeating(ParserRealExpression(), ParserSymbol(SymbolType.COMMA)) }
+        val tester = Tester { ParserRepeating(ParserReal(), ParserSymbol(SymbolType.COMMA)) }
         
         tester.parse("").isDone().isValue(emptyList())
         tester.parse("1").isOk(1).isDone().isValue(listOf(1.toExp())).resets(emptyList())
@@ -187,7 +187,7 @@ class TestParserRepeating
         val tester = Tester()
         {
             ParserRepeating(
-                ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression()),
+                ParserSequence(REAL to ParserReal(), BOOL to ParserBool()),
                 ParserSymbol(SymbolType.COMMA),
             )
         }
@@ -206,7 +206,7 @@ class TestParserRepeating
     fun `Given valid token, when parsing empty separator, then value produced`()
     {
         val tester =
-            Tester { ParserRepeating(ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression())) }
+            Tester { ParserRepeating(ParserSequence(REAL to ParserReal(), BOOL to ParserBool())) }
         
         tester.parse("1 true").isWip(1).isOk(1).isDone()
             .hasValue(REAL, 1.toExp())
@@ -220,7 +220,7 @@ class TestParserRepeating
         val tester = Tester()
         {
             ParserRepeating(
-                ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression()),
+                ParserSequence(REAL to ParserReal(), BOOL to ParserBool()),
                 ParserSymbol(SymbolType.COMMA),
             )
         }
@@ -232,7 +232,7 @@ class TestParserRepeating
     @Test
     fun `Given produced values, when resetting, then values are retained`()
     {
-        val parser = ParserRepeating(ParserRealExpression())
+        val parser = ParserRepeating(ParserReal())
             .also { it.parse(Numeric(1, null)) }
             .also { it.parse(EndOfFile) }
         val items = parser.produce()
@@ -248,7 +248,7 @@ class TestParserOptional
     @Test
     fun `Given valid token, when parsing simple, then value produced`()
     {
-        val tester = Tester { ParserOptional(ParserRealExpression()) }
+        val tester = Tester { ParserOptional(ParserReal()) }
         
         tester.parse("").isDone().isValue(null).resets()
         tester.parse("42").isOk(1).isDone().isValue(42.toExp()).resets()
@@ -258,7 +258,7 @@ class TestParserOptional
     fun `Given valid token, when parsing complex, then value produced`()
     {
         val tester =
-            Tester { ParserOptional(ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression())) }
+            Tester { ParserOptional(ParserSequence(REAL to ParserReal(), BOOL to ParserBool())) }
         
         tester.parse("").isDone()
             .hasValue(REAL, null).hasValue(BOOL, null)
@@ -270,7 +270,7 @@ class TestParserOptional
     fun `Given invalid token, when parsing, then correct error`()
     {
         val tester =
-            Tester { ParserOptional(ParserSequence(REAL to ParserRealExpression(), BOOL to ParserBoolExpression())) }
+            Tester { ParserOptional(ParserSequence(REAL to ParserReal(), BOOL to ParserBool())) }
         
         tester.parse("1 bah").isWip(1).isBad { ParseError.UnexpectedToken(it[1]) }
     }
@@ -279,8 +279,8 @@ class TestParserOptional
 class TestParserPattern
 {
     private val pattern = ParserSequence(
-        "lhs" to ParserRealExpression(),
-        "rhs" to ParserRealExpression(),
+        "lhs" to ParserReal(),
+        "rhs" to ParserReal(),
     )
     
     private fun converter(outcome: Parsers): Expression?

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.Test
 private fun <Type> Tester<Type>.isChain(wipCount: Int = 0, postOkCount: Int = 0): Tester<Type> =
     isWip(wipCount).isOk(postOkCount).isDone()
 
-class TestParserVariableDefinition
+class TestParserVariable
 {
-    private val tester = Tester { ParserVariableDefinition() }
+    private val tester = Tester { variableParserOf() }
     
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
@@ -40,9 +40,9 @@ class TestParserVariableDefinition
     }
 }
 
-class TestParserFunctionDefinition
+class TestParserFunction
 {
-    private val tester = Tester { ParserFunctionDefinition() }
+    private val tester = Tester { functionParserOf() }
     
     @Test
     fun `Given valid token, when parsing, then correctly parsed`()
@@ -102,7 +102,7 @@ class TestParserFunctionDefinition
 
 class TestParserSegment
 {
-    private val tester = Tester { ParserSegment() }
+    private val tester = Tester { segmentParser() }
     
     @Test
     fun `Given valid segment, when parsing, then correctly parsed`()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
@@ -102,7 +102,7 @@ class TestParserFunction
 
 class TestParserSegment
 {
-    private val tester = Tester { segmentParser() }
+    private val tester = Tester { segmentParserOf() }
     
     @Test
     fun `Given valid segment, when parsing, then correctly parsed`()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
@@ -13,7 +13,7 @@ private fun <Type> Tester<Type>.isChain(preOkCount: Int = 0, wipCount: Int = 0, 
 
 class TestParserExpression
 {
-    private val tester = Tester { ParserExpression() }
+    private val tester = Tester { expressionParserOf() }
     
     @Test
     fun `Given valid token, when parsing, then correct expression`()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 
 class TestParserStatement
 {
-    private val tester = Tester { ParserStatement() }
+    private val tester = Tester { statementParserOf() }
     
     @Test
     fun `Given valid token, when parsing, then correct statement`()
@@ -42,7 +42,7 @@ class TestParserStatement
 
 class TestParserScope
 {
-    private val tester = Tester { ParserScope() }
+    private val tester = Tester { scopeParserOf() }
     
     @Test
     fun `Given valid token, when parsing, then correct scope`()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserTokens.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserTokens.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.parser
 
+import com.github.derg.transpiler.source.lexeme.EndOfFile
 import com.github.derg.transpiler.source.lexeme.SymbolType
 import org.junit.jupiter.api.Test
 
@@ -35,6 +36,63 @@ class TestParserSymbol
     fun `Given invalid token, when parsing, then correct error`()
     {
         tester.parse("^^").isBad { ParseError.UnexpectedToken(it[0]) }
+        tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
+    }
+}
+
+class TestParserBool
+{
+    private val tester = Tester { ParserBool() }
+    
+    @Test
+    fun `Given valid token, when parsing, then correct product`()
+    {
+        tester.parse("true").isOk(1).isDone().isValue(true.toExp()).resets()
+        tester.parse("false").isOk(1).isDone().isValue(false.toExp()).resets()
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("if").isBad { ParseError.UnexpectedToken(it[0]) }
+        tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
+    }
+}
+
+class TestParserReal
+{
+    private val tester = Tester { ParserReal() }
+    
+    @Test
+    fun `Given valid token, when parsing, then correct product`()
+    {
+        tester.parse("4").isOk(1).isDone().isValue(4.toExp()).resets()
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
+    }
+}
+
+class TestParserText
+{
+    private val tester = Tester { ParserText() }
+    
+    @Test
+    fun `Given valid token, when parsing, then correct product`()
+    {
+        tester.parse("\"\"").isOk(1).isDone().isValue("".toExp()).resets()
+        tester.parse("\"foo\"").isOk(1).isDone().isValue("foo".toExp()).resets()
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
     }
 }


### PR DESCRIPTION
This pull request cleans up the parsing of various objects from the source code. The parsers for AST objects are now separated from the base parsers themselves, and only what really must be a parser, is one. Almost all AST objects may now be represented in terms of a standardized parser, which is combined with the recursive parser. This helps simplify the codebase, and makes it easier to extend and maintain.