### PR TITLE
Fix issue where optional parsers could not return null

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -17,7 +17,7 @@ fun parse(input: String): Segment
     val parser = segmentParserOf()
     val tokens = tokenize(input).map { it.data } + EndOfFile
     tokens.fold { parser.parse(it) }.valueOr { throw IllegalStateException("Failed parsing token: $it") }
-    return parser.produce() ?: throw IllegalStateException("Failed to produce segment")
+    return parser.produce()
 }
 
 /**
@@ -37,7 +37,7 @@ interface Parser<Type>
      * Pulls out the produced value from the parser, if it contains any finished items. A parser can only contain any
      * finished items by being provided with enough tokens to construct the item.
      */
-    fun produce(): Type?
+    fun produce(): Type
     
     /**
      * Provides a single new [token] to the parser. If the parser accepts the token, a success is returned. If the

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
@@ -114,10 +114,10 @@ private fun expressionPatternOf() = ParserSequence(
     "terms" to ParserRepeating(termPatternOf()),
 )
 
-private fun expressionOutcomeOf(values: Parsers): Expression?
+private fun expressionOutcomeOf(values: Parsers): Expression
 {
-    val base = values.produce<Expression>("base") ?: return null
-    val terms = values.produce<List<Parsers>>("terms") ?: emptyList()
+    val base = values.get<Expression>("base")
+    val terms = values.get<List<Parsers>>("terms")
     val ops = terms.produce<SymbolType>("operator")
     val rest = terms.produce<Expression>("term")
     return mergeRecursively(base, ops.zip(rest))
@@ -142,12 +142,8 @@ private fun functionCallPatternOf() = ParserSequence(
     "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
 )
 
-private fun functionCallOutcomeOf(outcome: Parsers): Expression?
-{
-    val name = outcome.produce<Name>("name") ?: return null
-    val params = outcome.produce<List<Argument>>("params") ?: emptyList()
-    return Access.Function(name, params)
-}
+private fun functionCallOutcomeOf(outcome: Parsers): Expression =
+    Access.Function(outcome["name"], outcome["params"])
 
 /**
  * Parses a subscript call expression from the token stream.
@@ -162,12 +158,8 @@ private fun subscriptCallPatternOf() = ParserSequence(
     "close" to ParserSymbol(SymbolType.CLOSE_BRACKET),
 )
 
-private fun subscriptCallOutcomeOf(values: Parsers): Expression?
-{
-    val name = values.produce<Name>("name") ?: return null
-    val params = values.produce<List<Argument>>("params") ?: emptyList()
-    return Access.Subscript(name, params)
-}
+private fun subscriptCallOutcomeOf(values: Parsers): Expression =
+    Access.Subscript(values["name"], values["params"])
 
 /**
  * Parses an expression from in-between parenthesis from the token stream.
@@ -181,8 +173,8 @@ private fun parenthesisPatternOf() = ParserSequence(
     "close" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
 )
 
-private fun parenthesisOutcomeOf(values: Parsers): Expression? =
-    values.produce("expr")
+private fun parenthesisOutcomeOf(values: Parsers): Expression =
+    values["expr"]
 
 /**
  * Parses a unary operator from the token stream.
@@ -195,12 +187,8 @@ private fun unaryOperatorPatternOf() = ParserSequence(
     "rhs" to basePatternOf(),
 )
 
-private fun unaryOperatorOutcomeOf(values: Parsers): Expression?
-{
-    val op = values.produce<SymbolType>("op") ?: return null
-    val rhs = values.produce<Expression>("rhs") ?: return null
-    return mergePrefix(op, rhs)
-}
+private fun unaryOperatorOutcomeOf(values: Parsers): Expression =
+    mergePrefix(values["op"], values["rhs"])
 
 /**
  * Parses a when expression from the token stream.
@@ -216,12 +204,12 @@ private fun whenPatternOf() = ParserSequence(
     "else" to ParserOptional(ParserSequence("else" to ParserSymbol(SymbolType.ELSE), "expr" to expressionParserOf())),
 )
 
-private fun whenOutcomeOf(values: Parsers): Expression?
+private fun whenOutcomeOf(values: Parsers): Expression
 {
-    val expression = values.produce<Expression>("expression") ?: return null
-    val default = values.produce<Parsers>("else")?.produce<Expression>("expr")
-    val first = listOf(values.produce<Pair<Expression, Expression>>("first") ?: return null)
-    val branches = values.produce<List<Pair<Expression, Expression>>>("remainder") ?: return null
+    val expression = values.get<Expression>("expression")
+    val default = values.get<Parsers?>("else")?.get<Expression>("expr")
+    val first = listOf(values.get<Pair<Expression, Expression>>("first"))
+    val branches = values.get<List<Pair<Expression, Expression>>>("remainder")
     return When(expression, first + branches, default)
 }
 
@@ -237,9 +225,9 @@ private fun whenBranchPatternOf() = ParserSequence(
     "expression" to expressionParserOf(),
 )
 
-private fun whenBranchOutcomeOf(values: Parsers): Pair<Expression, Expression>?
+private fun whenBranchOutcomeOf(values: Parsers): Pair<Expression, Expression>
 {
-    val cond = values.produce<Expression>("condition") ?: return null
-    val expr = values.produce<Expression>("expression") ?: return null
+    val cond = values.get<Expression>("condition")
+    val expr = values.get<Expression>("expression")
     return cond to expr
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
@@ -7,6 +7,7 @@ import com.github.derg.transpiler.source.lexeme.*
 import com.github.derg.transpiler.util.Result
 import com.github.derg.transpiler.util.failureOf
 import com.github.derg.transpiler.util.successOf
+import com.github.derg.transpiler.util.toSuccess
 
 /**
  * Parses a single identifier from the token stream.
@@ -16,7 +17,7 @@ class ParserName : Parser<Name>
     private var name: Name? = null
     
     override fun skipable(): Boolean = false
-    override fun produce(): Name? = name
+    override fun produce(): Name = name ?: throw IllegalStateException("No name has been parsed")
     override fun parse(token: Token): Result<ParseOk, ParseError>
     {
         if (name != null)
@@ -43,7 +44,7 @@ class ParserSymbol(vararg symbols: SymbolType) : Parser<SymbolType>
     private var type: SymbolType? = null
     
     override fun skipable(): Boolean = false
-    override fun produce(): SymbolType? = type
+    override fun produce(): SymbolType = type ?: throw IllegalStateException("No symbol has been parsed")
     override fun parse(token: Token): Result<ParseOk, ParseError>
     {
         if (type != null)
@@ -83,7 +84,7 @@ class ParserBool : Parser<Expression>
     }
     
     override fun skipable(): Boolean = false
-    override fun produce(): Expression? = expression
+    override fun produce(): Expression = expression ?: throw IllegalStateException("No expression has been parsed")
     override fun reset()
     {
         expression = null
@@ -108,7 +109,7 @@ class ParserReal : Parser<Expression>
     }
     
     override fun skipable(): Boolean = false
-    override fun produce(): Expression? = expression
+    override fun produce(): Expression = expression ?: throw IllegalStateException("No expression has been parsed")
     override fun reset()
     {
         expression = null
@@ -133,7 +134,7 @@ class ParserText : Parser<Expression>
     }
     
     override fun skipable(): Boolean = false
-    override fun produce(): Expression? = expression
+    override fun produce(): Expression = expression ?: throw IllegalStateException("No expression has been parsed")
     override fun reset()
     {
         expression = null

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
@@ -64,6 +64,6 @@ data class Scope(
  */
 data class Segment(
     val module: Name?,
-    val imports: Set<Name>,
+    val imports: List<Name>,
     val definitions: List<Definition>,
 )

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
@@ -8,7 +8,7 @@ class TestParser
     @Test
     fun `Given empty segment, when parsing, then correctly parsed`()
     {
-        val expected = segmentOf(module = null, imports = emptySet(), statements = emptyList())
+        val expected = segmentOf(module = null, imports = emptyList(), statements = emptyList())
         
         assertEquals(expected, parse(""))
     }
@@ -17,7 +17,7 @@ class TestParser
     fun `Given populated segment, when parsing, then correctly parsed`()
     {
         val variable = varOf("foo", 42.toExp("i8"))
-        val expected = segmentOf(module = null, imports = emptySet(), statements = listOf(variable))
+        val expected = segmentOf(module = null, imports = emptyList(), statements = listOf(variable))
         
         assertEquals(expected, parse("val foo = 42i8"))
     }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserCombinators.kt
@@ -174,10 +174,10 @@ class TestParserRepeating
         val tester = Tester { ParserRepeating(ParserReal(), ParserSymbol(SymbolType.COMMA)) }
         
         tester.parse("").isDone().isValue(emptyList())
-        tester.parse("1").isOk(1).isDone().isValue(listOf(1.toExp())).resets(emptyList())
-        tester.parse("1,").isOk(2).isDone().isValue(listOf(1.toExp())).resets(emptyList())
-        tester.parse("1,2").isOk(3).isDone().isValue(listOf(1.toExp(), 2.toExp())).resets(emptyList())
-        tester.parse("1,2,").isOk(4).isDone().isValue(listOf(1.toExp(), 2.toExp())).resets(emptyList())
+        tester.parse("1").isOk(1).isDone().isValue(listOf(1.toExp())).resets()
+        tester.parse("1,").isOk(2).isDone().isValue(listOf(1.toExp())).resets()
+        tester.parse("1,2").isOk(3).isDone().isValue(listOf(1.toExp(), 2.toExp())).resets()
+        tester.parse("1,2,").isOk(4).isDone().isValue(listOf(1.toExp(), 2.toExp())).resets()
     }
     
     @Test
@@ -277,17 +277,8 @@ class TestParserOptional
 
 class TestParserPattern
 {
-    private fun pattern() = ParserSequence(
-        "lhs" to ParserReal(),
-        "rhs" to ParserReal(),
-    )
-    
-    private fun converter(outcome: Parsers): Expression?
-    {
-        val lhs = outcome.produce<Expression>("lhs") ?: return null
-        val rhs = outcome.produce<Expression>("rhs") ?: return null
-        return Operator.Add(lhs, rhs)
-    }
+    private fun pattern() = ParserSequence("lhs" to ParserReal(), "rhs" to ParserReal())
+    private fun converter(outcome: Parsers) = Operator.Add(outcome["lhs"], outcome["rhs"])
     
     @Test
     fun `Given valid token, when parsing simple, then value produced`()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserMetadata.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserMetadata.kt
@@ -42,7 +42,7 @@ class TestParserSegment
     {
         tester.parse("").isChain().isValue(segmentOf())
         tester.parse("module foo").isChain(1, 1).isValue(segmentOf(module = "foo"))
-        tester.parse("use foo").isChain(1, 1).isValue(segmentOf(imports = setOf("foo")))
+        tester.parse("use foo").isChain(1, 1).isValue(segmentOf(imports = listOf("foo")))
         tester.parse("val foo = 0").isChain(3, 1).isValue(segmentOf(statements = listOf(varOf("foo", 0))))
         tester.parse("fun foo() {}").isChain(5, 1).isValue(segmentOf(statements = listOf(funOf("foo"))))
     }


### PR DESCRIPTION
This merge request makes it possible to return `null` from optional parsers. This enables more sane ways to address optional tokens, without causing a major grievance with handling `null`s as both successes and failures.