### PR TITLE
Remove inner functions and types

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -25,7 +25,7 @@ fun parse(input: String): Segment
  * together form the abstract syntax tree describing the full source code. The abstract syntax tree may be utilized to
  * perform various operations on the source code in a manner which is simpler than performing text manipulations.
  */
-interface Parser<Type>
+interface Parser<out Type>
 {
     /**
      * Determines whether the parser requires at least one token in order to produce any meaningful content or not. Any

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserDefinitions.kt
@@ -1,0 +1,87 @@
+package com.github.derg.transpiler.phases.parser
+
+import com.github.derg.transpiler.source.ast.Definition
+import com.github.derg.transpiler.source.lexeme.SymbolType
+
+/**
+ * Parses a single statement from the token stream.
+ */
+fun definitionParserOf(): Parser<Definition> = ParserAnyOf(
+    functionParserOf(),
+    typeParserOf(),
+    variableParserOf(),
+)
+
+/**
+ * Parses a function definition from the token stream.
+ */
+fun functionParserOf(): Parser<Definition.Function> =
+    ParserPattern(::functionPatternOf, ::functionOutcomeOf)
+
+private fun functionPatternOf() = ParserSequence(
+    "visibility" to visibilityParserOf(),
+    "fun" to ParserSymbol(SymbolType.FUN),
+    "name" to ParserName(),
+    "open_parenthesis" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
+    "parameters" to ParserRepeating(parameterParserOf(), ParserSymbol(SymbolType.COMMA)),
+    "close_parenthesis" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
+    "error" to ParserOptional(nameParserOf(SymbolType.COLON)),
+    "value" to ParserOptional(nameParserOf(SymbolType.ARROW)),
+    "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
+    "statements" to ParserRepeating(statementParserOf()),
+    "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
+)
+
+private fun functionOutcomeOf(values: Parsers) = Definition.Function(
+    name = values["name"],
+    valueType = values["value"],
+    errorType = values["error"],
+    parameters = values["parameters"],
+    visibility = values["visibility"],
+    statements = values["statements"],
+)
+
+/**
+ * Parses a type definition from the token stream.
+ */
+fun typeParserOf(): Parser<Definition.Type> =
+    ParserPattern(::typePatternOf, ::typeOutcomeOf)
+
+private fun typePatternOf() = ParserSequence(
+    "visibility" to visibilityParserOf(),
+    "type" to ParserSymbol(SymbolType.TYPE),
+    "name" to ParserName(),
+    "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
+    "properties" to ParserRepeating(propertyParserOf()),
+    "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
+)
+
+private fun typeOutcomeOf(values: Parsers) = Definition.Type(
+    name = values["name"],
+    visibility = values["visibility"],
+    properties = values["properties"],
+)
+
+/**
+ * Parses a variable definition from the token stream.
+ */
+fun variableParserOf(): Parser<Definition.Variable> =
+    ParserPattern(::variablePatternOf, ::variableOutcomeOf)
+
+private fun variablePatternOf() = ParserSequence(
+    "visibility" to visibilityParserOf(),
+    "assignability" to assignabilityParserOf(),
+    "mutability" to mutabilityParserOf(),
+    "name" to ParserName(),
+    "op" to ParserSymbol(SymbolType.ASSIGN),
+    "value" to expressionParserOf(),
+)
+
+private fun variableOutcomeOf(values: Parsers) = Definition.Variable(
+    name = values["name"],
+    type = null,
+    value = values["value"],
+    visibility = values["visibility"],
+    mutability = values["mutability"],
+    assignability = values["assignability"],
+)

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
@@ -205,7 +205,7 @@ fun segmentParserOf(): Parser<Segment> =
 private fun segmentPatternOf() = ParserSequence(
     "module" to ParserOptional(nameParserOf(SymbolType.MODULE)),
     "imports" to ParserRepeating(nameParserOf(SymbolType.USE)),
-    "definitions" to ParserRepeating(ParserAnyOf(variableParserOf(), functionParserOf(), typeParserOf())),
+    "definitions" to ParserRepeating(definitionParserOf()),
 )
 
 private fun segmentOutcomeOf(values: Parsers) = Segment(

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -21,13 +21,8 @@ private fun merge(name: Name, operator: SymbolType, rhs: Expression): Assignment
 /**
  * Parses a single statement from the token stream.
  */
-fun statementParserOf(): Parser<Statement> =
-    ParserPattern(::statementPatternOf) { it }
-
-private fun statementPatternOf(): Parser<Statement> = ParserAnyOf(
+fun statementParserOf(): Parser<Statement> = ParserAnyOf(
     variableParserOf(),
-    functionParserOf(),
-    typeParserOf(),
     assignmentParserOf(),
     branchParserOf(),
     invokeParserOf(),
@@ -118,77 +113,3 @@ private fun returnOutcomeOf(values: Parsers): Control.Return
 // TODO: Not a correct implementation of the parser - must also function with error handling
 private fun invokeParserOf(): Parser<Statement> =
     ParserPattern(::functionCallParserOf) { Control.Invoke(it) }
-
-/**
- * Parses a variable definition from the token stream.
- */
-fun variableParserOf(): Parser<Statement> =
-    ParserPattern(::variablePatternOf, ::variableOutcomeOf)
-
-private fun variablePatternOf() = ParserSequence(
-    "visibility" to visibilityParserOf(),
-    "assignability" to assignabilityParserOf(),
-    "mutability" to mutabilityParserOf(),
-    "name" to ParserName(),
-    "op" to ParserSymbol(SymbolType.ASSIGN),
-    "value" to expressionParserOf(),
-)
-
-private fun variableOutcomeOf(values: Parsers) = Definition.Variable(
-    name = values["name"],
-    type = null,
-    value = values["value"],
-    visibility = values["visibility"],
-    mutability = values["mutability"],
-    assignability = values["assignability"],
-)
-
-/**
- * Parses a function definition from the token stream.
- */
-fun functionParserOf(): Parser<Statement> =
-    ParserPattern(::functionPatternOf, ::functionOutcomeOf)
-
-private fun functionPatternOf() = ParserSequence(
-    "visibility" to visibilityParserOf(),
-    "fun" to ParserSymbol(SymbolType.FUN),
-    "name" to ParserName(),
-    "open_parenthesis" to ParserSymbol(SymbolType.OPEN_PARENTHESIS),
-    "parameters" to ParserRepeating(parameterParserOf(), ParserSymbol(SymbolType.COMMA)),
-    "close_parenthesis" to ParserSymbol(SymbolType.CLOSE_PARENTHESIS),
-    "error" to ParserOptional(nameParserOf(SymbolType.COLON)),
-    "value" to ParserOptional(nameParserOf(SymbolType.ARROW)),
-    "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
-    "statements" to ParserRepeating(statementParserOf()),
-    "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
-)
-
-private fun functionOutcomeOf(values: Parsers) = Definition.Function(
-    name = values["name"],
-    valueType = values["value"],
-    errorType = values["error"],
-    parameters = values["parameters"],
-    visibility = values["visibility"],
-    statements = values["statements"],
-)
-
-/**
- * Parses a type definition from the token stream.
- */
-fun typeParserOf(): Parser<Statement> =
-    ParserPattern(::typePatternOf, ::typeOutcomeOf)
-
-private fun typePatternOf() = ParserSequence(
-    "visibility" to visibilityParserOf(),
-    "type" to ParserSymbol(SymbolType.TYPE),
-    "name" to ParserName(),
-    "open_brace" to ParserSymbol(SymbolType.OPEN_BRACE),
-    "properties" to ParserRepeating(propertyParserOf()),
-    "close_brace" to ParserSymbol(SymbolType.CLOSE_BRACE),
-)
-
-private fun typeOutcomeOf(values: Parsers) = Definition.Type(
-    name = values["name"],
-    visibility = values["visibility"],
-    properties = values["properties"],
-)

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Declarators.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Declarators.kt
@@ -18,7 +18,7 @@ internal class Declarator(private val symbols: SymbolTable, ids: IdProvider)
     private val type = DeclaratorType(symbols, ids)
     private val vari = DeclaratorVariable(symbols, ids)
     
-    operator fun invoke(nodes: List<Statement>): Result<DeclaredSymbols, ResolveError>
+    operator fun invoke(nodes: List<Definition>): Result<DeclaredSymbols, ResolveError>
     {
         // Must ensure all functions and types are declared in advance, as they may be referring to each other in a
         // non-trivial manners. At any scope level, all functions and types must be able to "see" each other, even

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Definitions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Definitions.kt
@@ -1,0 +1,62 @@
+package com.github.derg.transpiler.source.ast
+
+import com.github.derg.transpiler.source.Assignability
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Name
+import com.github.derg.transpiler.source.Visibility
+
+/**
+ * Structural components within the source code must be defined to describe their behavior fully. While certain objects
+ * such as functions may be declared before being defined, all such objects must be defined before being used. The
+ * definition of the object varies from object to object.
+ */
+sealed interface Definition : Node
+{
+    /**
+     * Functions are smaller subroutines of a program which can perform a specialized workload, that are given a [name].
+     * Every function may return a [valueType], or raise an [errorType]. The value and error types are not required to
+     * be specified. Functions accept any number of [parameters], which allows different outcomes of invoking the
+     * function to take place.
+     *
+     * @param visibility The visibility of the function, to whom it is possible to access.
+     * @param statements The executable code which defines the function body.
+     */
+    data class Function(
+        val name: Name,
+        val valueType: Name?,
+        val errorType: Name?,
+        val parameters: List<Parameter>,
+        val visibility: Visibility,
+        val statements: List<Statement>,
+    ) : Definition
+    
+    /**
+     * All data structures are represented as types, which determines the shape of all data within a program. Types are
+     * not values within the program, but represents the shapes of values. This shape is given a [name], and may hold
+     * any number of additional [properties].
+     *
+     * @param visibility The visibility of the type, to whom it is possible to access.
+     */
+    data class Type(
+        val name: Name,
+        val visibility: Visibility,
+        val properties: List<Property>,
+    ) : Definition
+    
+    /**
+     * Variables are units which hold a specific [value] and associates the value with a specific [name]. Variables may
+     * optionally be given a [type], which is verified against the actual type of the expression. If the [type] is not
+     * specified, it is inferred from [value].
+     *
+     * @param visibility The visibility of the variable, to whom it is possible to access.
+     * @param mutability The kind of the variable, to which degree it is mutable.
+     */
+    data class Variable(
+        val name: Name,
+        val type: Name?,
+        val value: Expression,
+        val visibility: Visibility,
+        val mutability: Mutability,
+        val assignability: Assignability,
+    ) : Definition, Statement
+}

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
@@ -1,9 +1,6 @@
 package com.github.derg.transpiler.source.ast
 
-import com.github.derg.transpiler.source.Assignability
-import com.github.derg.transpiler.source.Mutability
 import com.github.derg.transpiler.source.Name
-import com.github.derg.transpiler.source.Visibility
 
 /**
  * Expressions may be turned into l-values by being stored in a variable of any kind. In doing so, the r-value
@@ -58,60 +55,4 @@ sealed interface Control : Statement
      * a value from a function indicates usually that the function has succeeded in producing a usable value.
      */
     data class Return(val expression: Expression?) : Control
-}
-
-/**
- * Structural components within the source code must be defined to describe their behavior fully. While certain objects
- * such as functions may be declared before being defined, all such objects must be defined before being used. The
- * definition of the object varies from object to object.
- */
-sealed interface Definition : Statement
-{
-    /**
-     * Functions are smaller subroutines of a program which can perform a specialized workload, that are given a [name].
-     * Every function may return a [valueType], or raise an [errorType]. The value and error types are not required to
-     * be specified. Functions accept any number of [parameters], which allows different outcomes of invoking the
-     * function to take place.
-     *
-     * @param visibility The visibility of the function, to whom it is possible to access.
-     * @param statements The executable code which defines the function body.
-     */
-    data class Function(
-        val name: Name,
-        val valueType: Name?,
-        val errorType: Name?,
-        val parameters: List<Parameter>,
-        val visibility: Visibility,
-        val statements: List<Statement>,
-    ) : Definition
-    
-    /**
-     * All data structures are represented as types, which determines the shape of all data within a program. Types are
-     * not values within the program, but represents the shapes of values. This shape is given a [name], and may hold
-     * any number of additional [properties].
-     *
-     * @param visibility The visibility of the type, to whom it is possible to access.
-     */
-    data class Type(
-        val name: Name,
-        val visibility: Visibility,
-        val properties: List<Property>,
-    ) : Definition
-    
-    /**
-     * Variables are units which hold a specific [value] and associates the value with a specific [name]. Variables may
-     * optionally be given a [type], which is verified against the actual type of the expression. If the [type] is not
-     * specified, it is inferred from [value].
-     *
-     * @param visibility The visibility of the variable, to whom it is possible to access.
-     * @param mutability The kind of the variable, to which degree it is mutable.
-     */
-    data class Variable(
-        val name: Name,
-        val type: Name?,
-        val value: Expression,
-        val visibility: Visibility,
-        val mutability: Mutability,
-        val assignability: Assignability,
-    ) : Definition
 }

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
@@ -33,10 +33,9 @@ data class Module(
 ) : Symbol
 {
     /**
-     * The symbols and instructions associated with the module will be assigned when the module is defined. The scope
-     * will hold all such information.
+     * The symbols associated with the module will be assigned when the module is defined.
      */
-    lateinit var scope: Scope
+    val symbols = SymbolTable()
 }
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/util/Result.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/util/Result.kt
@@ -23,7 +23,7 @@ val <Value, Error> Result<Value, Error>.isFailure: Boolean get() = this is Resul
 
 fun <Value, Error> Result<Value, Error>.valueOrNull(): Value? = (this as? Result.Success<Value>)?.value
 fun <Value, Error> Result<Value, Error>.errorOrNull(): Error? = (this as? Result.Failure<Error>)?.error
-fun <Value, Error> Result<Value, Error>.valueOrDie(): Value = valueOrNull() ?: throw IllegalStateException()
+fun <Value, Error> Result<Value, Error>.valueOrDie(): Value = valueOr { throw IllegalStateException(it.toString()) }
 
 /**
  * Folds the result value such that either the success value is returned, or a value is produced by [function].

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserDefinitions.kt
@@ -1,0 +1,182 @@
+package com.github.derg.transpiler.phases.parser
+
+import com.github.derg.transpiler.source.Assignability
+import com.github.derg.transpiler.source.Mutability
+import com.github.derg.transpiler.source.Passability
+import com.github.derg.transpiler.source.Visibility
+import com.github.derg.transpiler.source.lexeme.EndOfFile
+import org.junit.jupiter.api.Test
+
+/**
+ * Determines whether the current token stream is parsed correctly. The expectation is that there will be [wipCount]
+ * number of tokens resulting in [ParseOk.Incomplete], followed by [postOkCount] [ParseOk.Complete], before finally
+ * resulting in [ParseOk.Finished].
+ */
+private fun <Type> Tester<Type>.isChain(wipCount: Int = 0, postOkCount: Int = 0): Tester<Type> =
+    isWip(wipCount).isOk(postOkCount).isDone()
+
+class TestParserFunction
+{
+    private val tester = Tester { functionParserOf() }
+    
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        // Basic structure must be correctly parsed
+        tester.parse("fun foo() {}").isChain(5, 1).isValue(funOf("foo"))
+        tester.parse("fun foo() -> Foo {}").isChain(7, 1).isValue(funOf("foo", valType = "Foo"))
+        tester.parse("fun foo(): Foo {}").isChain(7, 1).isValue(funOf("foo", errType = "Foo"))
+        tester.parse("fun foo(): Foo -> Bar {}").isChain(9, 1).isValue(funOf("foo", valType = "Bar", errType = "Foo"))
+        
+        // Parameters must be correctly parsed
+        tester.parse("fun foo(mut a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", ass = Assignability.ASSIGNABLE))))
+        tester.parse("fun foo(ref a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", ass = Assignability.REFERENCE))))
+        tester.parse("fun foo(    a: Foo) {}").isChain(8, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", ass = Assignability.CONSTANT))))
+        
+        tester.parse("fun foo(in    a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.IN))))
+        tester.parse("fun foo(inout a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.INOUT))))
+        tester.parse("fun foo(out   a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.OUT))))
+        tester.parse("fun foo(move  a: Foo) {}").isChain(9, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.MOVE))))
+        tester.parse("fun foo(      a: Foo) {}").isChain(8, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.IN))))
+        
+        tester.parse("fun foo(a: Foo, b: Bar) {}").isChain(12, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo"), parOf("b", type = "Bar"))))
+        
+        // Default values for parameters must be supported
+        tester.parse("fun foo(a = 1) {}").isChain(8, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", value = 1))))
+        tester.parse("fun foo(a: Foo = 1) {}").isChain(10, 1)
+            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", value = 1))))
+        
+        // Visibility must be correctly parsed
+        tester.parse("exported  fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.EXPORTED))
+        tester.parse("public    fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PUBLIC))
+        tester.parse("protected fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PROTECTED))
+        tester.parse("private   fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PRIVATE))
+        tester.parse("          fun foo() {}").isChain(5, 1).isValue(funOf("foo", vis = Visibility.PRIVATE))
+    }
+    
+    @Test
+    fun `Given return statement, when parsing, then correctly parsed`()
+    {
+        tester.parse("fun f() { return _ }").isChain(7, 1)
+            .isValue(funOf("f", valType = null, statements = listOf(returnOf())))
+        tester.parse("fun f() -> Int { return 0 }").isChain(9, 1)
+            .isValue(funOf("f", valType = "Int", statements = listOf(returnOf(0))))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("fun").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("fun foo(").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
+    }
+    
+    @Test
+    fun `Given function with variable, when parsing, then correctly parsed`()
+    {
+        val expected = funOf("foo", statements = listOf(varOf("bar", 0)))
+        
+        tester.parse("fun foo() { val bar = 0 }").isChain(9, 1).isValue(expected)
+    }
+}
+
+class TestParserType
+{
+    private val tester = Tester { typeParserOf() }
+    
+    @Test
+    fun `Given valid segment, when parsing, then correctly parsed`()
+    {
+        // Basic structure must be correctly parsed
+        tester.parse("type Foo {}").isChain(3, 1).isValue(typeOf("Foo"))
+        
+        // Properties must be correctly parsed
+        tester.parse("type Foo { mut val a: Bar }").isChain(8, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", ass = Assignability.ASSIGNABLE))))
+        tester.parse("type Foo { ref val a: Bar }").isChain(8, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", ass = Assignability.REFERENCE))))
+        tester.parse("type Foo {     val a: Bar }").isChain(7, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", ass = Assignability.CONSTANT))))
+        
+        tester.parse("type Foo { val a: Bar }").isChain(7, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", mut = Mutability.IMMUTABLE))))
+        tester.parse("type Foo { var a: Bar }").isChain(7, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", mut = Mutability.MUTABLE))))
+        
+        tester.parse("type Foo { exported  val a: Bar }").isChain(8, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.EXPORTED))))
+        tester.parse("type Foo { public    val a: Bar }").isChain(8, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PUBLIC))))
+        tester.parse("type Foo { protected val a: Bar }").isChain(8, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PROTECTED))))
+        tester.parse("type Foo { private   val a: Bar }").isChain(8, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PRIVATE))))
+        tester.parse("type Foo {           val a: Bar }").isChain(7, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PRIVATE))))
+        
+        tester.parse("type Foo { val a: Foo val b: Bar }").isChain(11, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Foo"), propOf("b", type = "Bar"))))
+        
+        // Default values for properties must be supported
+        tester.parse("type Foo { val a = 1 }").isChain(7, 1)
+            .isValue(typeOf("Foo", props = listOf(propOf("a", value = 1))))
+        
+        // Visibility must be correctly parsed
+        tester.parse("exported  type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.EXPORTED))
+        tester.parse("public    type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.PUBLIC))
+        tester.parse("protected type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.PROTECTED))
+        tester.parse("private   type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.PRIVATE))
+        tester.parse("          type Foo {}").isChain(3, 1).isValue(typeOf("Foo", vis = Visibility.PRIVATE))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("type").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("type Foo {").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
+    }
+}
+
+class TestParserVariable
+{
+    private val tester = Tester { variableParserOf() }
+    
+    @Test
+    fun `Given valid token, when parsing, then correctly parsed`()
+    {
+        // Assignability must be correctly parsed
+        tester.parse("mut val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, ass = Assignability.ASSIGNABLE))
+        tester.parse("ref val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, ass = Assignability.REFERENCE))
+        tester.parse("    val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, ass = Assignability.CONSTANT))
+        
+        // Mutability must be correctly parsed
+        tester.parse("val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.IMMUTABLE))
+        tester.parse("var foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.MUTABLE))
+        
+        // Visibility must be correctly parsed
+        tester.parse("exported  val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.EXPORTED))
+        tester.parse("public    val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PUBLIC))
+        tester.parse("protected val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PROTECTED))
+        tester.parse("private   val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PRIVATE))
+        tester.parse("          val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, vis = Visibility.PRIVATE))
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("val").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("val foo =").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
@@ -1,9 +1,5 @@
 package com.github.derg.transpiler.phases.parser
 
-import com.github.derg.transpiler.source.Assignability
-import com.github.derg.transpiler.source.Mutability
-import com.github.derg.transpiler.source.Passability
-import com.github.derg.transpiler.source.Visibility
 import com.github.derg.transpiler.source.lexeme.EndOfFile
 import org.junit.jupiter.api.Test
 
@@ -29,6 +25,7 @@ class TestParserStatement
         tester.parse("a *= 1").isChain(2, 1).isValue("a" assignMul 1)
         tester.parse("a %= 1").isChain(2, 1).isValue("a" assignMod 1)
         tester.parse("a /= 1").isChain(2, 1).isValue("a" assignDiv 1)
+        tester.parse("val foo = 0").isChain(3, 1).isValue(varOf("foo", 0))
         
         // Control flow
         tester.parse("if 1 a = 2").isWip(4).isOk(1).isDone()
@@ -42,11 +39,6 @@ class TestParserStatement
         
         // Function call
         tester.parse("a()").isChain(2, 1).isValue(invokeOf("a".toFun()))
-        
-        // Definitions
-        tester.parse("val foo = 0").isChain(3, 1).isValue(varOf("foo", 0))
-        tester.parse("fun foo() {}").isChain(5, 1).isValue(funOf("foo"))
-        tester.parse("type Foo {}").isChain(3, 1).isValue(typeOf("Foo"))
     }
     
     @Test
@@ -54,171 +46,5 @@ class TestParserStatement
     {
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
         tester.parse("a =").isWip(2).isBad { ParseError.UnexpectedToken(EndOfFile) }
-    }
-}
-
-class TestParserVariable
-{
-    private val tester = Tester { variableParserOf() }
-    
-    @Test
-    fun `Given valid token, when parsing, then correctly parsed`()
-    {
-        // Assignability must be correctly parsed
-        tester.parse("mut val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, ass = Assignability.ASSIGNABLE))
-        tester.parse("ref val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, ass = Assignability.REFERENCE))
-        tester.parse("    val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, ass = Assignability.CONSTANT))
-        
-        // Mutability must be correctly parsed
-        tester.parse("val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.IMMUTABLE))
-        tester.parse("var foo = 0").isChain(3, 1).isValue(varOf("foo", 0, mut = Mutability.MUTABLE))
-        
-        // Visibility must be correctly parsed
-        tester.parse("exported  val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.EXPORTED))
-        tester.parse("public    val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PUBLIC))
-        tester.parse("protected val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PROTECTED))
-        tester.parse("private   val foo = 0").isChain(4, 1).isValue(varOf("foo", 0, vis = Visibility.PRIVATE))
-        tester.parse("          val foo = 0").isChain(3, 1).isValue(varOf("foo", 0, vis = Visibility.PRIVATE))
-    }
-    
-    @Test
-    fun `Given invalid token, when parsing, then correct error`()
-    {
-        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("val").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("val foo =").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
-    }
-}
-
-class TestParserFunction
-{
-    private val tester = Tester { functionParserOf() }
-    
-    @Test
-    fun `Given valid token, when parsing, then correctly parsed`()
-    {
-        // Basic structure must be correctly parsed
-        tester.parse("fun foo() {}").isChain(5, 1).isValue(funOf("foo"))
-        tester.parse("fun foo() -> Foo {}").isChain(7, 1).isValue(funOf("foo", valType = "Foo"))
-        tester.parse("fun foo(): Foo {}").isChain(7, 1).isValue(funOf("foo", errType = "Foo"))
-        tester.parse("fun foo(): Foo -> Bar {}").isChain(9, 1).isValue(funOf("foo", valType = "Bar", errType = "Foo"))
-        
-        // Parameters must be correctly parsed
-        tester.parse("fun foo(mut a: Foo) {}").isChain(9, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", ass = Assignability.ASSIGNABLE))))
-        tester.parse("fun foo(ref a: Foo) {}").isChain(9, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", ass = Assignability.REFERENCE))))
-        tester.parse("fun foo(    a: Foo) {}").isChain(8, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", ass = Assignability.CONSTANT))))
-        
-        tester.parse("fun foo(in    a: Foo) {}").isChain(9, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.IN))))
-        tester.parse("fun foo(inout a: Foo) {}").isChain(9, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.INOUT))))
-        tester.parse("fun foo(out   a: Foo) {}").isChain(9, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.OUT))))
-        tester.parse("fun foo(move  a: Foo) {}").isChain(9, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.MOVE))))
-        tester.parse("fun foo(      a: Foo) {}").isChain(8, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", pas = Passability.IN))))
-        
-        tester.parse("fun foo(a: Foo, b: Bar) {}").isChain(12, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo"), parOf("b", type = "Bar"))))
-        
-        // Default values for parameters must be supported
-        tester.parse("fun foo(a = 1) {}").isChain(8, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", value = 1))))
-        tester.parse("fun foo(a: Foo = 1) {}").isChain(10, 1)
-            .isValue(funOf("foo", params = listOf(parOf("a", type = "Foo", value = 1))))
-        
-        // Visibility must be correctly parsed
-        tester.parse("exported  fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.EXPORTED))
-        tester.parse("public    fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PUBLIC))
-        tester.parse("protected fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PROTECTED))
-        tester.parse("private   fun foo() {}").isChain(6, 1).isValue(funOf("foo", vis = Visibility.PRIVATE))
-        tester.parse("          fun foo() {}").isChain(5, 1).isValue(funOf("foo", vis = Visibility.PRIVATE))
-    }
-    
-    @Test
-    fun `Given return statement, when parsing, then correctly parsed`()
-    {
-        tester.parse("fun f() { return _ }").isChain(7, 1)
-            .isValue(funOf("f", valType = null, statements = listOf(returnOf())))
-        tester.parse("fun f() -> Int { return 0 }").isChain(9, 1)
-            .isValue(funOf("f", valType = "Int", statements = listOf(returnOf(0))))
-    }
-    
-    @Test
-    fun `Given invalid token, when parsing, then correct error`()
-    {
-        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("fun").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("fun foo(").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
-    }
-    
-    @Test
-    fun `Given function with variable, when parsing, then correctly parsed`()
-    {
-        val expected = funOf("foo", statements = listOf(varOf("bar", 0)))
-        
-        tester.parse("fun foo() { val bar = 0 }").isChain(9, 1).isValue(expected)
-    }
-}
-
-class TestParserType
-{
-    private val tester = Tester { typeParserOf() }
-    
-    @Test
-    fun `Given valid segment, when parsing, then correctly parsed`()
-    {
-        // Basic structure must be correctly parsed
-        tester.parse("type Foo {}").isChain(3, 1).isValue(typeOf("Foo"))
-        
-        // Properties must be correctly parsed
-        tester.parse("type Foo { mut val a: Bar }").isChain(8, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", ass = Assignability.ASSIGNABLE))))
-        tester.parse("type Foo { ref val a: Bar }").isChain(8, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", ass = Assignability.REFERENCE))))
-        tester.parse("type Foo {     val a: Bar }").isChain(7, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", ass = Assignability.CONSTANT))))
-        
-        tester.parse("type Foo { val a: Bar }").isChain(7, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", mut = Mutability.IMMUTABLE))))
-        tester.parse("type Foo { var a: Bar }").isChain(7, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", mut = Mutability.MUTABLE))))
-        
-        tester.parse("type Foo { exported  val a: Bar }").isChain(8, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.EXPORTED))))
-        tester.parse("type Foo { public    val a: Bar }").isChain(8, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PUBLIC))))
-        tester.parse("type Foo { protected val a: Bar }").isChain(8, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PROTECTED))))
-        tester.parse("type Foo { private   val a: Bar }").isChain(8, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PRIVATE))))
-        tester.parse("type Foo {           val a: Bar }").isChain(7, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Bar", vis = Visibility.PRIVATE))))
-        
-        tester.parse("type Foo { val a: Foo val b: Bar }").isChain(11, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", type = "Foo"), propOf("b", type = "Bar"))))
-        
-        // Default values for properties must be supported
-        tester.parse("type Foo { val a = 1 }").isChain(7, 1)
-            .isValue(typeOf("Foo", props = listOf(propOf("a", value = 1))))
-        
-        // Visibility must be correctly parsed
-        tester.parse("exported  type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.EXPORTED))
-        tester.parse("public    type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.PUBLIC))
-        tester.parse("protected type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.PROTECTED))
-        tester.parse("private   type Foo {}").isChain(4, 1).isValue(typeOf("Foo", vis = Visibility.PRIVATE))
-        tester.parse("          type Foo {}").isChain(3, 1).isValue(typeOf("Foo", vis = Visibility.PRIVATE))
-    }
-    
-    @Test
-    fun `Given invalid token, when parsing, then correct error`()
-    {
-        tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("type").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("type Foo {").isWip(3).isBad { ParseError.UnexpectedToken(EndOfFile) }
     }
 }


### PR DESCRIPTION
This pull request makes inner functions and types (symbols declared inside another function) as forbidden. This means all such symbols must be declared at top-level scopes (i.e. module or namespace scope), rather than in any arbitrary scope. This change simplifies function definitions, and reduces the number of ways to do the same thing (lambdas will do this workload).