### PR TITLE
Remove subscript operator to reserve symbols for generics

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Expressions.kt
@@ -37,7 +37,6 @@ internal class ConverterExpression(private val symbols: ThirSymbolTable)
         is AstText         -> parse(node.value, node.literal)
         is AstCatch        -> TODO()
         is AstRaise        -> TODO()
-        is AstSubscript    -> TODO()
         is AstThreeWay     -> TODO()
         is AstWhen         -> TODO()
     }

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Expressions.kt
@@ -18,13 +18,6 @@ data class AstRead(val name: String) : AstAccess
  */
 data class AstCall(val name: String, val temArgs: List<AstArgument>, val valArgs: List<AstArgument>) : AstAccess
 
-/**
- * All subscript calls refers to the subscript operator being invoked on an instance with the given [name]. Every
- * subscript call is permitted an arbitrary number of [arguments].
- */
-@Deprecated("To be removed, see https://github.com/derg-lang/transpiler/issues/83")
-data class AstSubscript(val name: String, val arguments: List<AstArgument>) : AstAccess
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Constants
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
@@ -4,11 +4,6 @@ import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.lexeme.*
 import org.junit.jupiter.api.*
 
-@Deprecated("Remove when subscript is removed", ReplaceWith("nothing, kill it"))
-private fun String.toSub(vararg arguments: AstArgument) = AstSubscript(this, arguments.toList())
-@Deprecated("Remove when subscript is removed", ReplaceWith("nothing, kill it"))
-private fun Any.toArg(name: String? = null) = AstArgument(name, ast)
-
 /**
  * Determines whether the current token stream is parsed correctly. The expectation is that there will be [preOkCount]
  * number of tokens resulting in [ParseOk.Complete], followed by [wipCount] [ParseOk.Incomplete], then followed by
@@ -40,11 +35,6 @@ class TestParserExpression
         tester.parse("f(1,)").isChain(1, 3, 1).isValue("f".astCall(1)).resets()
         tester.parse("f(1,2)").isChain(1, 4, 1).isValue("f".astCall(1, 2)).resets()
         tester.parse("f(bar = 1)").isChain(1, 4, 1).isValue("f".astCall("bar" to 1)).resets()
-        tester.parse("f[]").isChain(1, 1, 1).isValue("f".toSub()).resets()
-        tester.parse("f[1]").isChain(1, 2, 1).isValue("f".toSub(1.toArg())).resets()
-        tester.parse("f[1,]").isChain(1, 3, 1).isValue("f".toSub(1.toArg())).resets()
-        tester.parse("f[1,2]").isChain(1, 4, 1).isValue("f".toSub(1.toArg(), 2.toArg())).resets()
-        tester.parse("f[bar = 1]").isChain(1, 4, 1).isValue("f".toSub(1.toArg("bar"))).resets()
         
         // Structural
         tester.parse("(1)").isChain(0, 2, 1).isValue(1.ast).resets()


### PR DESCRIPTION
Closes #83.

This pull request removes the subscript operator `[]`, as this functionality can be replicated using normal parenthesis `()`. By leaving the square brackets available, they ca be re-purposed for generics instead.