### PR TITLE
Fix issue where syntax errors were undetected

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -9,12 +9,12 @@ import com.github.derg.transpiler.utils.*
  * Parses the [input] string into a single segment, forming a part of the overall program. The total collection of all
  * segments makes up the program.
  */
-fun parse(input: String): AstSegment
+fun parse(input: String): Result<AstSegment, ParseError>
 {
     val parser = segmentParserOf()
     val tokens = tokenize(input).map { it.data } + EndOfFile
-    tokens.fold { parser.parse(it) }.valueOr { throw IllegalStateException("Failed parsing token: $it") }
-    return parser.produce()
+    tokens.fold { parser.parse(it) }.valueOr { return it.toFailure() }
+    return parser.produce().toSuccess()
 }
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
@@ -206,6 +206,7 @@ private fun segmentPatternOf() = ParserSequence(
     "module" to ParserOptional(nameParserOf(SymbolType.MODULE)),
     "imports" to ParserRepeating(nameParserOf(SymbolType.USE)),
     "definitions" to ParserRepeating(definitionParserOf()),
+    "end" to ParserEnd,
 )
 
 private fun segmentOutcomeOf(values: Parsers) = AstSegment(

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
@@ -136,3 +136,22 @@ class ParserText : Parser<AstExpression>
         expression = null
     }
 }
+
+/**
+ * Parses the end of the token stream. Can only be used to represent the end of the token stream.
+ */
+object ParserEnd : Parser<Unit>
+{
+    override fun parse(token: Token): Result<ParseOk, ParseError>
+    {
+        if (token !is EndOfFile)
+            return ParseError.UnexpectedToken(token).toFailure()
+        return ParseOk.Finished.toSuccess()
+    }
+    
+    override fun skipable(): Boolean = false
+    override fun produce() = Unit
+    override fun reset()
+    {
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
@@ -1,8 +1,9 @@
 package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.lexeme.*
+import com.github.derg.transpiler.utils.*
 import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.*
 
 class TestParser
 {
@@ -11,7 +12,7 @@ class TestParser
     {
         val expected = astSegmentOf(module = null, imports = emptyList(), statements = emptyList())
         
-        assertEquals(expected, parse(""))
+        assertSuccess(expected, parse(""))
     }
     
     @Test
@@ -20,6 +21,14 @@ class TestParser
         val variable = astVarOf("foo", 42)
         val expected = astSegmentOf(module = null, imports = emptyList(), statements = listOf(variable))
         
-        assertEquals(expected, parse("val foo = 42"))
+        assertSuccess(expected, parse("val foo = 42"))
+    }
+    
+    @Test
+    fun `Given syntax error, when parsing, then correct error`()
+    {
+        val expected = ParseError.UnexpectedToken(Symbol(SymbolType.COMMA))
+        
+        assertFailure(expected, parse("use foo,"))
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserMetadata.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserMetadata.kt
@@ -41,11 +41,11 @@ class TestParserSegment
     @Test
     fun `Given valid segment, when parsing, then correctly parsed`()
     {
-        tester.parse("").isChain().isValue(astSegmentOf())
-        tester.parse("module foo").isChain(1, 1).isValue(astSegmentOf(module = "foo"))
-        tester.parse("use foo").isChain(1, 1).isValue(astSegmentOf(imports = listOf("foo")))
-        tester.parse("val foo = 0").isChain(3, 1).isValue(astSegmentOf(statements = listOf(astVarOf("foo", 0))))
-        tester.parse("fun foo() {}").isChain(5, 1).isValue(astSegmentOf(statements = listOf(astFunOf("foo"))))
+        tester.parse("").isDone().isValue(astSegmentOf())
+        tester.parse("module foo").isWip(2).isDone().isValue(astSegmentOf(module = "foo"))
+        tester.parse("use foo").isWip(2).isDone().isValue(astSegmentOf(imports = listOf("foo")))
+        tester.parse("val foo = 0").isWip(4).isDone().isValue(astSegmentOf(statements = listOf(astVarOf("foo", 0))))
+        tester.parse("fun foo() {}").isWip(6).isDone().isValue(astSegmentOf(statements = listOf(astFunOf("foo"))))
     }
     
     @Test

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserTokens.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserTokens.kt
@@ -96,3 +96,20 @@ class TestParserText
         tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
     }
 }
+
+class TestParserEnd
+{
+    private val tester = Tester { ParserEnd }
+    
+    @Test
+    fun `Given valid token, when parsing, then correct product`()
+    {
+        tester.parse("").isDone()
+    }
+    
+    @Test
+    fun `Given invalid token, when parsing, then correct error`()
+    {
+        tester.parse("bah").isBad { ParseError.UnexpectedToken(it[0]) }
+    }
+}


### PR DESCRIPTION
This pull request fixes the issue where syntax errors in the parsing phase does not result in a compilation error. When a syntax error occurs in-between constructs at the segment level, the parser will discover that the segment did not end with a end-of-file token, thus resulting in a compilation error.