### PR TITLE
Replace sealed class with sealed interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.6.10</version>
+                <version>1.9.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -72,13 +72,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>1.7.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit5</artifactId>
-            <version>1.7.0</version>
-            <scope>test</scope>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/Parser.kt
@@ -55,25 +55,25 @@ interface Parser<out Type>
  * revealed by the parse outcome. Some parsers will require an infinite stream of additional tokens, whereas some tokens
  * are satisfied by a finite number of tokens.
  */
-sealed class ParseOk
+sealed interface ParseOk
 {
     /**
      * The parser is currently in process of assembling additional data, and thus will require more tokens.
      */
-    object Incomplete : ParseOk()
+    data object Incomplete : ParseOk
     
     /**
      * The parser has received enough tokens to complete assembling its data. It may potentially require more tokens to
      * further assemble additional data, but is currently in an indeterminate state - another token must be provided to
      * determine the final state.
      */
-    object Complete : ParseOk()
+    data object Complete : ParseOk
     
     /**
      * The parser has received enough tokens to finish its data, and will not need additional tokens. The parser has
      * rejected the provided token. The token should be provided to the next candidate parser instead.
      */
-    object Finished : ParseOk()
+    data object Finished : ParseOk
 }
 
 /**
@@ -81,10 +81,10 @@ sealed class ParseOk
  * taking place. This is always the case if the source code ends abruptly or otherwise does not respect the grammar of
  * the programming language.
  */
-sealed class ParseError
+sealed interface ParseError
 {
     /**
      * The parser expected a specific token, but instead received an unexpected [token].
      */
-    data class UnexpectedToken(val token: Token) : ParseError()
+    data class UnexpectedToken(val token: Token) : ParseError
 }

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Statements.kt
@@ -30,7 +30,7 @@ data class AstEvaluate(val expression: AstExpression) : AstControl
  * Specifies that the execution flow should exit the current function, returning control flow back to the caller. Note
  * that the function cannot be exited in this manner if the function expects a return value.
  */
- object AstReturn : AstControl
+data object AstReturn : AstControl
 
 /**
  * Specifies that a function should raise a specific [expression]. The raise statement functions similarly to the return

--- a/src/main/kotlin/com/github/derg/transpiler/source/lexeme/Tokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/lexeme/Tokens.kt
@@ -4,36 +4,36 @@ package com.github.derg.transpiler.source.lexeme
  * A single token represents a single lexeme in the source code. Tokens may be extracted from the source code in various
  * manners depending on each type of lexeme, although the overall result may be summarized as a single token type.
  */
-sealed class Token
+sealed interface Token
 
 /**
  * The very last token in the sequence of tokens; it marks the end of the token stream.
  */
-object EndOfFile : Token()
+data object EndOfFile : Token
 
 /**
  * All symbols such as variables, functions, type, namespaces, packages, etc. must be given a unique name. The
  * identifier token represents any such object by [name], although the token does not hold information determining which
  * object type it is applicable to.
  */
-data class Identifier(val name: String) : Token()
+data class Identifier(val name: String) : Token
 
 /**
  * The token holds a raw numerical literal of a specific [value] and optional [type].
  */
-data class Numeric(val value: Number, val type: String?) : Token()
+data class Numeric(val value: Number, val type: String?) : Token
 
 /**
  * The token holds a raw textual literal of a specific [value] and optional [type].
  */
-data class Textual(val value: String, val type: String?) : Token()
+data class Textual(val value: String, val type: String?) : Token
 
 /**
  * Source code requires the use of keywords, structural symbols, as well as operators to specify what various objects
  * are, how the logic of the program flows, and which operations are to be performed. The token represents the [type] of
  * symbol.
  */
-data class Symbol(val type: SymbolType) : Token()
+data class Symbol(val type: SymbolType) : Token
 
 /**
  * The various types of symbols which are valid tokens.

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
@@ -26,7 +26,7 @@ data class ThirEvaluate(val value: ThirValue) : ThirInstruction
 /**
  * Exist the current function call, returning control flow to whoever called the function in the first place.
  */
-object ThirReturn : ThirInstruction
+data object ThirReturn : ThirInstruction
 
 /**
  * Exits the current function call, returning control flow to whoever called the function in the first place. The

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestStatements.kt
@@ -5,7 +5,6 @@ import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
-import kotlin.test.Test
 
 class TestConverterStatements
 {


### PR DESCRIPTION
This pull request updates to Kotlin 1.9, and removes some unnecessary stuff. Replaces the use of sealed classes with sealed interfaces.