### PR TITLE
Add High Intermediate Representation variant of source code

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -1,0 +1,163 @@
+package com.github.derg.transpiler.phases.converter
+
+import com.github.derg.transpiler.source.*
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.hir.*
+import java.util.*
+
+/**
+ * Converts the provided AST [segments] into a HIR package. The input segments are all used to form the single package.
+ * Note that segments from another package, must be separately converted into the HIR structure.
+ */
+fun convert(segments: List<AstSegment>) = HirPackage(
+    id = UUID.randomUUID(),
+    name = "TODO - package name",
+    modules = segments.groupBy { it.module ?: "TODO - module name" }.map { module(it.key, it.value) }
+)
+
+private fun module(name: String, segments: List<AstSegment>) = HirModule(
+    id = UUID.randomUUID(),
+    name = name,
+    segments = segments.map { it.toHir() },
+)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Implementation details
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+internal fun AstVariable.toHirConstant() = HirConstant(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = visibility,
+    type = type?.let { HirTypeStruct(it, emptyList(), Mutability.IMMUTABLE) },
+    value = value.toHir(),
+)
+
+/**
+ *
+ */
+internal fun AstFunction.toHir() = HirFunction(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = visibility,
+    value = valueType?.let { HirTypeStruct(it, emptyList(), Mutability.IMMUTABLE) },
+    error = errorType?.let { HirTypeStruct(it, emptyList(), Mutability.IMMUTABLE) },
+    instructions = statements.map { it.toHir() },
+    generics = emptyList(),
+    variables = statements.filterIsInstance<AstVariable>().map { it.toHirVariable() },
+    parameters = parameters.map { it.toHir() },
+)
+
+/**
+ *
+ */
+internal fun AstParameter.toHir() = HirParameter(
+    id = UUID.randomUUID(),
+    name = name,
+    passability = passability,
+    type = HirTypeStruct(type, emptyList(), Mutability.IMMUTABLE),
+    value = value?.toHir(),
+)
+
+/**
+ *
+ */
+internal fun AstProperty.toHir() = HirField(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = visibility,
+    mutability = mutability,
+    assignability = assignability,
+    type = HirTypeStruct(type, emptyList(), Mutability.IMMUTABLE),
+    value = value?.toHir(),
+)
+
+/**
+ *
+ */
+internal fun AstSegment.toHir() = HirSegment(
+    id = UUID.randomUUID(),
+    name = "TODO - segment name",
+    imports = imports.toSet(),
+    structs = definitions.filterIsInstance<AstType>().map { it.toHir() },
+    concepts = emptyList(),
+    constants = definitions.filterIsInstance<AstVariable>().map { it.toHirConstant() },
+    functions = definitions.filterIsInstance<AstFunction>().map { it.toHir() },
+)
+
+/**
+ *
+ */
+internal fun AstType.toHir() = HirStruct(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = visibility,
+    fields = properties.map { it.toHir() },
+    methods = emptyList(),
+    generics = emptyList(),
+)
+
+/**
+ *
+ */
+internal fun AstVariable.toHirVariable() = HirVariable(
+    id = UUID.randomUUID(),
+    name = name,
+    mutability = mutability,
+    assignability = assignability,
+    type = type?.let { HirTypeStruct(it, emptyList(), Mutability.IMMUTABLE) },
+    value = value.toHir(),
+)
+
+/**
+ * Converts [this] expression from AST to HIR. The data structure will be encoded with appropriate default information
+ * where information is missing in the AST.
+ */
+internal fun AstExpression.toHir(): HirValue = when (this)
+{
+    is AstCall         -> TODO()
+    is AstRead         -> HirLoad(name, emptyList())
+    is AstBool         -> HirBool(value)
+    is AstInteger      -> HirInteger(value, literal)
+    is AstDecimal      -> HirDecimal(value, literal)
+    is AstText         -> HirText(value, literal)
+    is AstAdd          -> HirAdd(lhs.toHir(), rhs.toHir())
+    is AstAnd          -> HirAnd(lhs.toHir(), rhs.toHir())
+    is AstCatch        -> TODO()
+    is AstDivide       -> HirDiv(lhs.toHir(), rhs.toHir())
+    is AstEqual        -> HirEq(lhs.toHir(), rhs.toHir())
+    is AstGreater      -> HirGt(lhs.toHir(), rhs.toHir())
+    is AstGreaterEqual -> HirGe(lhs.toHir(), rhs.toHir())
+    is AstLess         -> HirLt(lhs.toHir(), rhs.toHir())
+    is AstLessEqual    -> HirLe(lhs.toHir(), rhs.toHir())
+    is AstMinus        -> HirMinus(expression.toHir())
+    is AstModulo       -> HirMod(lhs.toHir(), rhs.toHir())
+    is AstMultiply     -> HirMul(lhs.toHir(), rhs.toHir())
+    is AstNot          -> HirNot(expression.toHir())
+    is AstNotEqual     -> HirNe(lhs.toHir(), rhs.toHir())
+    is AstOr           -> HirOr(lhs.toHir(), rhs.toHir())
+    is AstPlus         -> HirPlus(expression.toHir())
+    is AstRaise        -> TODO()
+    is AstSubtract     -> HirSub(lhs.toHir(), rhs.toHir())
+    is AstThreeWay     -> TODO()
+    is AstXor          -> HirXor(lhs.toHir(), rhs.toHir())
+    is AstWhen         -> TODO()
+}
+
+/**
+ * Converts [this] statement from AST to HIR. The data structure will be encoded with appropriate default information
+ * where information is missing in the AST.
+ */
+internal fun AstStatement.toHir(): HirInstruction = when (this)
+{
+    is AstAssign      -> HirAssign(HirLoad(name, emptyList()), expression.toHir())
+    is AstBranch      -> HirBranch(predicate.toHir(), success.map { it.toHir() }, failure.map { it.toHir() })
+    is AstEvaluate    -> HirEvaluate(expression.toHir())
+    is AstReturn      -> HirReturn
+    is AstReturnError -> HirReturnError(expression.toHir())
+    is AstReturnValue -> HirReturnValue(expression.toHir())
+    is AstVariable    -> HirAssign(HirLoad(name, emptyList()), value.toHir())
+}

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Scope.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Scope.kt
@@ -1,0 +1,56 @@
+package com.github.derg.transpiler.phases.resolver
+
+import com.github.derg.transpiler.source.hir.*
+import java.util.*
+
+/**
+ * Scopes represents the symbols which are accessible at a certain layer in the source code. Scopes may be nested inside
+ * each other, forming a hierarchy of scopes.
+ *
+ * @param parent The outer scope in which this scope lives in.
+ */
+class Scope(private val parent: Scope?)
+{
+    private val _symbols = mutableMapOf<String, MutableList<HirSymbol>>()
+    
+    /**
+     * The collection of symbols which have been registered into this scope.
+     */
+    val symbols: List<HirSymbol>
+        get() = _symbols.values.flatten()
+    
+    /**
+     * Registers the [symbol] id in this scope. Note that each symbol must only be registered once.
+     */
+    fun register(symbol: HirSymbol)
+    {
+        _symbols.getOrPut(symbol.name) { mutableListOf() }.add(symbol)
+    }
+    
+    /**
+     * Resolves the given [name] to all symbols visible from the current scope, including all outer scopes.
+     */
+    fun resolve(name: String): List<HirSymbol>
+    {
+        val inner = _symbols[name] ?: emptyList()
+        val outer = parent?.resolve(name) ?: emptyList()
+        
+        return inner + outer
+    }
+    
+    /**
+     * Resolves the given [name] to all symbols visible from the current scope, including all outer scopes. If [Type] is
+     * specified more narrowly, then all symbols which are not of that type are omitted.
+     */
+    @JvmName("resolveType")
+    inline fun <reified Type : HirSymbol> resolve(name: String): List<Type> =
+        resolve(name).filterIsInstance<Type>()
+    
+    override fun toString(): String = _symbols.toString()
+    override fun hashCode(): Int = _symbols.hashCode()
+    override fun equals(other: Any?): Boolean = when (other)
+    {
+        is Scope -> _symbols == other._symbols
+        else     -> false
+    }
+}

--- a/src/main/kotlin/com/github/derg/transpiler/source/Constants.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/Constants.kt
@@ -1,0 +1,20 @@
+package com.github.derg.transpiler.source
+
+/*
+ * The names of the literal functions for a wide variety of builtin types. These literals are used across the entire
+ * compiler, ensuring that the names of literals are easily accessible for convenience' sake.
+ */
+const val LIT_NAME_I32 = "i32"
+const val LIT_NAME_I64 = "i64"
+const val LIT_NAME_STR = "s"
+
+/*
+ * The names of the builtin data types. These names are used to refer to the specific data structures which are built
+ * into the compiler. These data structures cannot be represented in source code as libraries without great effort and
+ * poor support.
+ */
+const val TYPE_VOID = "__builtin_void"
+const val TYPE_BOOL = "__builtin_bool"
+const val TYPE_INT32 = "__builtin_i32"
+const val TYPE_INT64 = "__builtin_i64"
+const val TYPE_STR = "__builtin_str"

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
@@ -1,0 +1,138 @@
+package com.github.derg.transpiler.source.hir
+
+import com.github.derg.transpiler.phases.resolver.*
+import com.github.derg.transpiler.source.*
+import java.util.*
+
+/**
+ * The collection of all builtin types, functions, literals, and everything else. The builtin scope contains everything
+ * which is needed to compile any source code into a valid program.
+ */
+object Builtin
+{
+    /**
+     * Main entrance to any sort of symbol resolution begins at the global scope level. All other symbols must be
+     * registered in a scope nested from the global scope in order to be valid. The global scope will contain all
+     * builtin symbols, and should never have any non-builtin symbols registered into it.
+     */
+    val GLOBAL_SCOPE = Scope(null)
+    
+    /**
+     * Void represents a special type that can never be instantiated. This type is used to represent the absence of a
+     * value, where a value would normally be expected. This is commonly used to model functions which has no return
+     * value or error, and to capture errors where an expression is used as statements.
+     */
+    val VOID = registerType(TYPE_VOID)
+    
+    val BOOL = registerType(TYPE_BOOL)
+    val BOOL_AND = registerInfixOp(Symbol.AND.symbol, BOOL, BOOL, null)
+    val BOOL_EQ = registerInfixOp(Symbol.EQUAL.symbol, BOOL, BOOL, null)
+    val BOOL_NE = registerInfixOp(Symbol.NOT_EQUAL.symbol, BOOL, BOOL, null)
+    val BOOL_NOT = registerPrefixOp(Symbol.NOT.symbol, BOOL, BOOL, null)
+    val BOOL_OR = registerInfixOp(Symbol.OR.symbol, BOOL, BOOL, null)
+    val BOOL_XOR = registerInfixOp(Symbol.XOR.symbol, BOOL, BOOL, null)
+    
+    val INT32 = registerType(TYPE_INT32)
+    val INT32_LIT = registerLiteral(LIT_NAME_I32, INT32)
+    val INT32_EQ = registerInfixOp(Symbol.EQUAL.symbol, INT32, BOOL, null)
+    val INT32_GE = registerInfixOp(Symbol.GREATER_EQUAL.symbol, INT32, BOOL, null)
+    val INT32_GT = registerInfixOp(Symbol.GREATER.symbol, INT32, BOOL, null)
+    val INT32_LE = registerInfixOp(Symbol.LESS_EQUAL.symbol, INT32, BOOL, null)
+    val INT32_LT = registerInfixOp(Symbol.LESS.symbol, INT32, BOOL, null)
+    val INT32_NE = registerInfixOp(Symbol.NOT_EQUAL.symbol, INT32, BOOL, null)
+    val INT32_ADD = registerInfixOp(Symbol.PLUS.symbol, INT32, INT32, VOID)
+    val INT32_DIV = registerInfixOp(Symbol.DIVIDE.symbol, INT32, INT32, VOID)
+    val INT32_MOD = registerInfixOp(Symbol.MODULO.symbol, INT32, INT32, VOID)
+    val INT32_MUL = registerInfixOp(Symbol.MULTIPLY.symbol, INT32, INT32, VOID)
+    val INT32_NEG = registerPrefixOp(Symbol.MINUS.symbol, INT32, INT32, VOID)
+    val INT32_POS = registerPrefixOp(Symbol.PLUS.symbol, INT32, INT32, VOID)
+    val INT32_SUB = registerInfixOp(Symbol.MINUS.symbol, INT32, INT32, VOID)
+    
+    val INT64 = registerType(TYPE_INT64)
+    val INT64_LIT = registerLiteral(LIT_NAME_I64, INT64)
+    val INT64_EQ = registerInfixOp(Symbol.EQUAL.symbol, INT64, BOOL, null)
+    val INT64_GE = registerInfixOp(Symbol.GREATER_EQUAL.symbol, INT64, BOOL, null)
+    val INT64_GT = registerInfixOp(Symbol.GREATER.symbol, INT64, BOOL, null)
+    val INT64_LE = registerInfixOp(Symbol.LESS_EQUAL.symbol, INT64, BOOL, null)
+    val INT64_LT = registerInfixOp(Symbol.LESS.symbol, INT64, BOOL, null)
+    val INT64_NE = registerInfixOp(Symbol.NOT_EQUAL.symbol, INT64, BOOL, null)
+    val INT64_ADD = registerInfixOp(Symbol.PLUS.symbol, INT64, INT64, VOID)
+    val INT64_DIV = registerInfixOp(Symbol.DIVIDE.symbol, INT64, INT64, VOID)
+    val INT64_MOD = registerInfixOp(Symbol.MODULO.symbol, INT64, INT64, VOID)
+    val INT64_MUL = registerInfixOp(Symbol.MULTIPLY.symbol, INT64, INT64, VOID)
+    val INT64_NEG = registerPrefixOp(Symbol.MINUS.symbol, INT64, INT64, VOID)
+    val INT64_POS = registerPrefixOp(Symbol.PLUS.symbol, INT64, INT64, VOID)
+    val INT64_SUB = registerInfixOp(Symbol.MINUS.symbol, INT64, INT64, VOID)
+    
+    // TODO: Support strings somehow
+    val STR = registerType(TYPE_STR)
+    val STR_LIT = registerLiteral(LIT_NAME_STR, VOID)
+}
+
+/**
+ * Registers a new type with the given [name].
+ */
+private fun registerType(name: String) = HirStruct(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = Visibility.EXPORTED,
+    fields = emptyList(),
+    methods = emptyList(),
+    generics = emptyList(),
+).also(Builtin.GLOBAL_SCOPE::register)
+
+/**
+ * Defines a new literal with the given [name] and [type].
+ */
+private fun registerLiteral(name: String, type: HirStruct) = HirLiteral(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = Visibility.EXPORTED,
+    value = HirTypeStruct(type.name, emptyList(), Mutability.IMMUTABLE),
+    instructions = emptyList(),
+    variables = emptyList(),
+    parameter = paramOf("value", type),
+).also(Builtin.GLOBAL_SCOPE::register)
+
+/**
+ * Defines a new infix operator for the given [name]. The [parameter] type will be the same for both the left- and the
+ * right-hand side expressions. The operator returns a value of the given [value] and [error] types.
+ */
+private fun registerInfixOp(name: String, parameter: HirStruct, value: HirStruct, error: HirStruct?) = HirFunction(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = Visibility.EXPORTED,
+    value = HirTypeStruct(value.name, emptyList(), Mutability.IMMUTABLE),
+    error = error?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    instructions = emptyList(),
+    generics = emptyList(),
+    variables = emptyList(),
+    parameters = listOf(paramOf("lhs", parameter), paramOf("rhs", parameter)),
+).also(Builtin.GLOBAL_SCOPE::register)
+
+/**
+ * Defines a new prefix operator for the given [name]. The [parameter] type determines which expressions are legal. The
+ * operator returns a value of the given [value] and [error] types.
+ */
+private fun registerPrefixOp(name: String, parameter: HirStruct, value: HirStruct, error: HirStruct?) = HirFunction(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = Visibility.EXPORTED,
+    value = HirTypeStruct(value.name, emptyList(), Mutability.IMMUTABLE),
+    error = error?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    instructions = emptyList(),
+    generics = emptyList(),
+    variables = emptyList(),
+    parameters = listOf(paramOf("rhs", parameter)),
+).also(Builtin.GLOBAL_SCOPE::register)
+
+/**
+ * Defines a new function parameter of the given [type].
+ */
+private fun paramOf(name: String, type: HirStruct) = HirParameter(
+    id = UUID.randomUUID(),
+    name = name,
+    passability = Passability.IN,
+    type = HirTypeStruct(type.name, emptyList(), Mutability.IMMUTABLE),
+    value = null,
+)

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
@@ -1,0 +1,45 @@
+package com.github.derg.transpiler.source.hir
+
+/**
+ * Executable parts of the program are represented as instructions. Every instruction performs exactly one task,
+ * although it may be composed out of multiple calculations.
+ */
+sealed interface HirInstruction
+
+/**
+ * Assigns the specified [value] to the object located under the given [instance].
+ */
+data class HirAssign(val instance: HirValue, val value: HirValue) : HirInstruction
+
+/**
+ * Conditional execution is possible by branching the control flow one a [predicate]. If the predicates matches, the
+ * [success] branch is selected, otherwise the [failure] branch is selected.
+ */
+data class HirBranch(
+    val predicate: HirValue,
+    val success: List<HirInstruction>,
+    val failure: List<HirInstruction>,
+) : HirInstruction
+
+/**
+ * Evaluates the [value], and executes any side effects which may arise as a consequence. The [value] is not permitted
+ * to evaluate to any non-void value or error.
+ */
+data class HirEvaluate(val value: HirValue) : HirInstruction
+
+/**
+ * Exist the current function call, returning control flow to whoever called the function in the first place.
+ */
+data object HirReturn : HirInstruction
+
+/**
+ * Exits the current function call, returning control flow to whoever called the function in the first place. The
+ * error value of the function is provided by the given [value].
+ */
+data class HirReturnError(val value: HirValue) : HirInstruction
+
+/**
+ * Exits the current function call, returning control flow to whoever called the function in the first place. The
+ * return value of the function is provided by the given [value].
+ */
+data class HirReturnValue(val value: HirValue) : HirInstruction

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Metadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Metadata.kt
@@ -1,0 +1,59 @@
+package com.github.derg.transpiler.source.hir
+
+import com.github.derg.transpiler.source.*
+
+/**
+ * Type annotations indicates which type a specific object is. All variables must be declared with a specific type,
+ * either by the developer or by the compiler. In many cases, the compiler can deduce the type, although the developer
+ * must have the option of specifying the type when it is ambiguous.
+ */
+sealed interface HirType
+
+/**
+ * The struct type describes a concrete type by [name], which may be specialized with any number of [generics].
+ */
+// TODO: Is this needed?
+data class HirTypeStruct(
+    val name: String,
+    val generics: List<HirTypedParameter>,
+    val mutability: Mutability,
+) : HirType
+
+/**
+ * The function type describes a function returning a [value] and [error] type, with any number of [parameters]. The
+ * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
+ */
+// TODO: Is this needed?
+data class HirTypeFunction(
+    val value: HirType?,
+    val error: HirType?,
+    val parameters: List<HirTypedParameter>,
+) : HirType
+
+/**
+ * The literal type describes a function returning a [value] type, with exactly one [parameter]. The parameter must be a
+ * builtin type.
+ */
+// TODO: Is this needed?
+data class HirTypeLiteral(
+    val value: HirType,
+    val parameter: HirTypeStruct,
+) : HirType
+
+/**
+ * The parameter type describing what the type of the parameter is. All function parameters must have a [name] and
+ * [value] type.
+ */
+data class HirTypedParameter(
+    val name: String,
+    val value: HirType,
+)
+
+/**
+ * An optionally named parameter used when invoking a function. The parameter may be given a specific [name], but must
+ * be given a specific [value].
+ */
+data class HirNamedParameter(
+    val name: String?,
+    val value: HirValue,
+)

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
@@ -1,0 +1,218 @@
+package com.github.derg.transpiler.source.hir
+
+import com.github.derg.transpiler.source.*
+import java.util.*
+
+/**
+ *
+ */
+sealed interface HirSymbol
+{
+    val id: UUID
+    val name: String
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Structures
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Packages represents an entire program or library, containing all relevant code and constructs to make it work.
+ */
+data class HirPackage(
+    override val id: UUID,
+    override val name: String,
+    
+    // Symbols present within the object
+    val modules: List<HirModule>,
+) : HirSymbol
+
+/**
+ * Modules are high-level constructs which contains any number of identifiable objects. Modules may import any number of
+ * other modules, forming the dependency graph between them.
+ */
+data class HirModule(
+    override val id: UUID,
+    override val name: String,
+    
+    // Symbols present within the object
+    val segments: List<HirSegment>,
+) : HirSymbol
+
+/**
+ * A segment represents a single source file of code.
+ */
+data class HirSegment(
+    override val id: UUID,
+    override val name: String,
+    val imports: Set<String>,
+    
+    // Symbols present within the object
+    val structs: List<HirStruct>,
+    val concepts: List<HirConcept>,
+    val constants: List<HirConstant>,
+    val functions: List<HirFunction>,
+) : HirSymbol
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Types
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Concepts represents a contract a type must satisfy. It does not provide any functionality or data.
+ */
+data class HirConcept(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    
+    // Symbols present within the object
+    val fields: List<HirField>,
+    val generics: List<HirGeneric>,
+    val functions: List<HirFunction>,
+) : HirSymbol
+
+/**
+ * Functions are callable subroutines which allows a program to be structured into smaller segments.
+ */
+data class HirFunction(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    val value: HirType?,
+    val error: HirType?,
+    val instructions: List<HirInstruction>,
+    
+    // Symbols present within the object
+    val generics: List<HirGeneric>,
+    val variables: List<HirVariable>,
+    val parameters: List<HirParameter>,
+) : HirSymbol
+
+/**
+ * Methods are callable subroutines which operate on a specific type, allowing programs to be decomposed into smaller
+ * segments.
+ */
+data class HirMethod(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    val type: HirType,
+    val value: HirType?,
+    val error: HirType?,
+    val instructions: List<HirInstruction>,
+    
+    // Symbols present within the object
+    val generics: List<HirGeneric>,
+    val variables: List<HirVariable>,
+    val parameters: List<HirParameter>,
+) : HirSymbol
+
+/**
+ * Literals are special data conversion functions, which allows the developer to convert raw numbers and text literals
+ * into ordinary types.
+ */
+data class HirLiteral(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    val value: HirType,
+    val instructions: List<HirInstruction>,
+    
+    // Symbols present within the object
+    val variables: List<HirVariable>,
+    val parameter: HirParameter,
+) : HirSymbol
+
+/**
+ * Data structures represents a collection of properties. It does not provide any additional functionality.
+ */
+data class HirStruct(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    
+    // Symbols present within the object
+    val fields: List<HirField>,
+    val methods: List<HirMethod>,
+    val generics: List<HirGeneric>,
+) : HirSymbol
+
+/**
+ * Closures are anonymous callable subroutines which allows values from the surroundings to be captured.
+ */
+// TODO: This may need to be represented as a synthetic type instead; closures cannot be named in the general case. By
+//       representing it as a construct of its own like this, there are likely many edge cases to consider. It is likely
+//       more sensible to implement closures via unnamed data structures containing all captured values, overloaded as
+//       callable.
+//data class HirClosure(
+//    val id: UUID,
+//    val parameters: List<HirParameter>,
+//    val instructions: List<HirInstruction>,
+//    val error: HirType?,
+//    val output: HirType?,
+//)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Values
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Constants represents a value or attribute associated with a module. They cannot be re-assigned or mutated in any way,
+ * shape, or form.
+ */
+data class HirConstant(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    val type: HirType?,
+    val value: HirValue,
+) : HirSymbol
+
+/**
+ * Fields represents a value or attribute associated with an instance of a type.
+ */
+data class HirField(
+    override val id: UUID,
+    override val name: String,
+    val visibility: Visibility,
+    val mutability: Mutability,
+    val assignability: Assignability,
+    val type: HirType,
+    val value: HirValue?,
+) : HirSymbol
+
+/**
+ * Type parameters represents a generic type used in a construct. These parameters are used to generalize across a whole
+ * range of types, rather than just a single type. Generics may be constrained by any number of [concepts].
+ */
+data class HirGeneric(
+    override val id: UUID,
+    override val name: String,
+    val type: HirType?,
+    val value: HirValue?,
+    val concepts: List<String>,
+) : HirSymbol
+
+/**
+ * The parameter represents a specific input expected to a callable construct.
+ */
+data class HirParameter(
+    override val id: UUID,
+    override val name: String,
+    val passability: Passability,
+    val type: HirType,
+    val value: HirValue?,
+) : HirSymbol
+
+/**
+ * Variables represents a value which exists exclusively on the stack, and can only be defined within a callable body.
+ */
+data class HirVariable(
+    override val id: UUID,
+    override val name: String,
+    val mutability: Mutability,
+    val assignability: Assignability,
+    val type: HirType?,
+    val value: HirValue,
+) : HirSymbol

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
@@ -1,0 +1,83 @@
+package com.github.derg.transpiler.source.hir
+
+import java.math.*
+
+/**
+ *
+ */
+sealed interface HirValue
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Resolutions
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Loads the value bound to the identifier with the given [name]. The identifier may refer to either a value bound to
+ * any memory address, or any named symbol. When referring to a function, [generics] may be used to disambiguate which
+ * instance is intended.
+ */
+data class HirLoad(
+    val name: String,
+    val generics: List<HirNamedParameter>,
+) : HirValue
+
+/**
+ * Retrieves the value of the given [field] from the given [instance]. The object may be an object which exists on the
+ * stack or heap. When referring to a method, [generics] may be used to disambiguate which method is intended.
+ */
+// TODO: Should objects within modules be accessible via this value? Possibly yes, to unify instance and module access.
+//       In doing so, the syntax could be simplified, using only `foo.bar`, instead of also including `foo::bar`. The
+//       downside being name resolution becomes much more finicky as modules cannot have the same names as other items.
+data class HirRead(
+    val instance: HirValue,
+    val field: String,
+    val generics: List<HirNamedParameter>,
+) : HirValue
+
+/**
+ * Invokes the callable [instance] using the provided [parameters]. The arguments are specified in the same order in
+ * which they appear in source code. In some cases, the callable cannot be resolved without additional information about
+ * the callable template specialization.
+ */
+data class HirCall(
+    val instance: HirValue,
+    val parameters: List<HirNamedParameter>,
+) : HirValue
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Constants
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+data class HirBool(val value: Boolean) : HirValue
+data class HirInteger(val value: BigInteger, val literal: String) : HirValue
+data class HirDecimal(val value: BigDecimal, val literal: String) : HirValue
+data class HirText(val value: String, val literal: String) : HirValue
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Operators
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Arithmetic
+data class HirAdd(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirDiv(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirMod(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirMul(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirSub(val lhs: HirValue, val rhs: HirValue) : HirValue
+
+// Comparison
+data class HirEq(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirNe(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirGe(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirGt(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirLe(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirLt(val lhs: HirValue, val rhs: HirValue) : HirValue
+
+// Logic
+data class HirAnd(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirOr(val lhs: HirValue, val rhs: HirValue) : HirValue
+data class HirXor(val lhs: HirValue, val rhs: HirValue) : HirValue
+
+// Unary
+data class HirMinus(val rhs: HirValue) : HirValue
+data class HirNot(val rhs: HirValue) : HirValue
+data class HirPlus(val rhs: HirValue) : HirValue

--- a/src/test/kotlin/com/github/derg/transpiler/phases/converter/TestConverter.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/converter/TestConverter.kt
@@ -1,0 +1,34 @@
+package com.github.derg.transpiler.phases.converter
+
+import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.hir.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+
+class TestConverter
+{
+    @Test
+    fun `Given expression, when converting, then correct outcome`()
+    {
+        assertEquals(1 hirAdd 2, (1 astAdd 2).toHir())
+        assertEquals(1 hirDiv 2, (1 astDiv 2).toHir())
+        assertEquals(1 hirMod 2, (1 astMod 2).toHir())
+        assertEquals(1 hirMul 2, (1 astMul 2).toHir())
+        assertEquals(1 hirSub 2, (1 astSub 2).toHir())
+        
+        assertEquals(1 hirEq 2, (1 astEq 2).toHir())
+        assertEquals(1 hirNe 2, (1 astNe 2).toHir())
+        assertEquals(1 hirGe 2, (1 astGe 2).toHir())
+        assertEquals(1 hirGt 2, (1 astGt 2).toHir())
+        assertEquals(1 hirLe 2, (1 astLe 2).toHir())
+        assertEquals(1 hirLt 2, (1 astLt 2).toHir())
+        
+        assertEquals(true hirAnd false, (true astAnd false).toHir())
+        assertEquals(true hirOr false, (true astOr false).toHir())
+        assertEquals(true hirXor false, (true astXor false).toHir())
+        
+        assertEquals(true.hirNot, true.astNot.toHir())
+        assertEquals(1.hirMinus, 1.astMinus.toHir())
+        assertEquals(1.hirPlus, 1.astPlus.toHir())
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -1,0 +1,109 @@
+package com.github.derg.transpiler.source.hir
+
+import com.github.derg.transpiler.source.*
+import java.util.*
+
+// Literals
+
+val Any.hir: HirValue
+    get() = when (this)
+    {
+        is Boolean -> HirBool(this)
+        is Int     -> HirInteger(toBigInteger(), LIT_NAME_I32)
+        is Long    -> HirInteger(toBigInteger(), LIT_NAME_I64)
+        is String  -> HirText(this, LIT_NAME_STR)
+        else       -> throw IllegalArgumentException("Value $this does not represent a valid hir value")
+    }
+
+// Expressions
+
+infix fun Any.hirEq(that: Any): HirValue = HirEq(this.hir, that.hir)
+infix fun Any.hirNe(that: Any): HirValue = HirNe(this.hir, that.hir)
+infix fun Any.hirGe(that: Any): HirValue = HirGe(this.hir, that.hir)
+infix fun Any.hirGt(that: Any): HirValue = HirGt(this.hir, that.hir)
+infix fun Any.hirLe(that: Any): HirValue = HirLe(this.hir, that.hir)
+infix fun Any.hirLt(that: Any): HirValue = HirLt(this.hir, that.hir)
+
+infix fun Any.hirAdd(that: Any): HirValue = HirAdd(this.hir, that.hir)
+infix fun Any.hirDiv(that: Any): HirValue = HirDiv(this.hir, that.hir)
+infix fun Any.hirMod(that: Any): HirValue = HirMod(this.hir, that.hir)
+infix fun Any.hirMul(that: Any): HirValue = HirMul(this.hir, that.hir)
+infix fun Any.hirSub(that: Any): HirValue = HirSub(this.hir, that.hir)
+
+infix fun Any.hirAnd(that: Any): HirValue = HirAnd(this.hir, that.hir)
+infix fun Any.hirOr(that: Any): HirValue = HirOr(this.hir, that.hir)
+infix fun Any.hirXor(that: Any): HirValue = HirXor(this.hir, that.hir)
+
+val Any.hirNot: HirValue get() = HirNot(hir)
+val Any.hirMinus: HirValue get() = HirMinus(hir)
+val Any.hirPlus: HirValue get() = HirPlus(hir)
+
+val HirSymbol.hirLoad: HirValue get() = HirLoad(name, emptyList())
+fun HirFunction.hirCall(vararg parameters: Any) = HirCall(hirLoad, parameters.map { null hirArg it })
+infix fun String?.hirArg(that: Any) = HirNamedParameter(this, that.hir)
+
+// Instructions
+
+val HirValue.hirEval get() = HirEvaluate(this)
+val Any.hirReturnError get() = HirReturnError(hir)
+val Any.hirReturnValue get() = HirReturnValue(hir)
+
+infix fun HirVariable.hirAssign(that: Any) = HirAssign(hirLoad, that.hir)
+
+// Symbols
+
+fun hirFunOf(
+    name: String = UUID.randomUUID().toString(),
+    value: HirStruct? = null,
+    error: HirStruct? = null,
+    params: List<HirParameter> = emptyList(),
+) = HirFunction(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = Visibility.PRIVATE,
+    value = value?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    error = error?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    instructions = emptyList(),
+    generics = emptyList(),
+    variables = emptyList(),
+    parameters = params,
+)
+
+fun hirLitOf(
+    name: String = UUID.randomUUID().toString(),
+    value: HirStruct = Builtin.VOID,
+    param: HirParameter = hirParamOf(type = Builtin.INT32),
+) = HirLiteral(
+    id = UUID.randomUUID(),
+    name = name,
+    visibility = Visibility.PRIVATE,
+    value = HirTypeStruct(value.name, emptyList(), Mutability.IMMUTABLE),
+    instructions = emptyList(),
+    variables = emptyList(),
+    parameter = param,
+)
+
+fun hirParamOf(
+    name: String = UUID.randomUUID().toString(),
+    type: HirStruct = Builtin.VOID,
+    value: HirValue? = null,
+) = HirParameter(
+    id = UUID.randomUUID(),
+    name = name,
+    passability = Passability.IN,
+    type = HirTypeStruct(type.name, emptyList(), Mutability.IMMUTABLE),
+    value = value,
+)
+
+fun hirVarOf(
+    name: String = UUID.randomUUID().toString(),
+    type: HirStruct? = null,
+    value: Any = 0,
+) = HirVariable(
+    id = UUID.randomUUID(),
+    name = name,
+    mutability = Mutability.IMMUTABLE,
+    assignability = Assignability.CONSTANT,
+    type = type?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    value = value.hir,
+)


### PR DESCRIPTION
This pull request introduces some basic representation of the high-level intermediate representation of source code. This variant does not have to be a true representation of the source code, which is the responsibility of the AST variant. The HIR variant is intended to represent the intention of the source code at a high level, before type-checking takes place.