### PR TITLE
 113 replace reference to builtin literals with literal name 

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserTokens.kt
@@ -3,7 +3,6 @@ package com.github.derg.transpiler.phases.parser
 import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.lexeme.*
-import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 
 /**
@@ -101,7 +100,7 @@ class ParserInteger : Parser<AstValue>
             return ParseOk.Finished.toSuccess()
         
         val number = token as? Numeric ?: return ParseError.UnexpectedToken(token).toFailure()
-        expression = AstInteger(number.value, number.type ?: Builtin.INT32_LIT.name)
+        expression = AstInteger(number.value, number.type ?: LIT_NAME_I32)
         return ParseOk.Complete.toSuccess()
     }
     
@@ -126,7 +125,7 @@ class ParserText : Parser<AstValue>
             return ParseOk.Finished.toSuccess()
         
         val string = token as? Textual ?: return ParseError.UnexpectedToken(token).toFailure()
-        expression = AstText(string.value, string.type ?: Builtin.STR_LIT.name)
+        expression = AstText(string.value, string.type ?: LIT_NAME_STR)
         return ParseOk.Complete.toSuccess()
     }
     

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Expressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Expressions.kt
@@ -124,9 +124,9 @@ internal class ConverterExpression(private val symbols: ThirSymbolTable)
     private fun parse(value: Number, literal: String): Result<ThirValue, ResolveError>
     {
         // TODO: Fail operation if number is too large
-        if (literal == Builtin.INT32_LIT.name)
+        if (literal == LIT_NAME_I32)
             return ThirInt32Const(value.toInt()).toSuccess()
-        if (literal == Builtin.INT64_LIT.name)
+        if (literal == LIT_NAME_I64)
             return ThirInt64Const(value.toLong()).toSuccess()
         
         // TODO: Support custom literals
@@ -139,7 +139,7 @@ internal class ConverterExpression(private val symbols: ThirSymbolTable)
     private fun parse(value: String, literal: String): Result<ThirValue, ResolveError>
     {
         // TODO: Fail operation if string is invalid
-        if (literal == Builtin.STR_LIT.name)
+        if (literal == LIT_NAME_STR)
             TODO("not implemented")
         
         // TODO: Support custom literals

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestExpressions.kt
@@ -254,8 +254,8 @@ class TestConverterExpression
         @Test
         fun `Given builtin types, when resolving, then correct outcome`()
         {
-            assertSuccess(1.thir, converter(AstInteger(BigInteger.ONE, Builtin.INT32_LIT.name)))
-            assertSuccess(2L.thir, converter(AstInteger(BigInteger.TWO, Builtin.INT64_LIT.name)))
+            assertSuccess(1.thir, converter(AstInteger(BigInteger.ONE, LIT_NAME_I32)))
+            assertSuccess(2L.thir, converter(AstInteger(BigInteger.TWO, LIT_NAME_I64)))
         }
         
         @Test

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -1,7 +1,6 @@
 package com.github.derg.transpiler.source.ast
 
 import com.github.derg.transpiler.source.*
-import com.github.derg.transpiler.source.thir.*
 import java.util.*
 
 /////////////////////
@@ -13,9 +12,9 @@ val Any.ast: AstValue
     {
         is AstValue -> this
         is Boolean  -> AstBool(this)
-        is Int      -> AstInteger(toBigInteger(), Builtin.INT32_LIT.name)
-        is Long     -> AstInteger(toBigInteger(), Builtin.INT64_LIT.name)
-        is String   -> AstText(this, Builtin.STR_LIT.name)
+        is Int      -> AstInteger(toBigInteger(), LIT_NAME_I32)
+        is Long     -> AstInteger(toBigInteger(), LIT_NAME_I64)
+        is String   -> AstText(this, LIT_NAME_STR)
         else        -> throw IllegalArgumentException("Value $this does not represent a valid ast value")
     }
 


### PR DESCRIPTION
Simple little refactor to remove the dependency on `Builtin` in the thir module. These builtins will be replaced with the hir variants in a later pull request.