### PR TITLE
Change value, error, and parameter types to be explicit

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -47,8 +47,11 @@ internal fun AstVariable.toHirConstant() = HirConstant(
 internal fun AstFunction.toHir() = HirFunction(
     id = UUID.randomUUID(),
     name = name,
-    value = valueType?.toHir(),
-    error = errorType?.toHir(),
+    type = HirTypeFunction(
+        value = valueType?.toHir(),
+        error = errorType?.toHir(),
+        parameters = parameters.map { HirTypedParameter(it.name, it.type.toHir()) },
+    ),
     visibility = visibility,
     instructions = statements.map { it.toHir() },
     generics = emptyList(),

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
@@ -22,52 +22,64 @@ object Builtin
      * value, where a value would normally be expected. This is commonly used to model functions which has no return
      * value or error, and to capture errors where an expression is used as statements.
      */
-    val VOID = registerStruct(VOID_TYPE_NAME)
+    // TODO: Remove the void type; it should never appear in the type system.
+    private val VOID = registerStruct(VOID_TYPE_NAME)
+    private val VOID_TYPE = typeOf(VOID)
     
     val BOOL = registerStruct(BOOL_TYPE_NAME)
-    val BOOL_AND = registerInfixOp(Symbol.AND, BOOL, BOOL, null)
-    val BOOL_EQ = registerInfixOp(Symbol.EQUAL, BOOL, BOOL, null)
-    val BOOL_NE = registerInfixOp(Symbol.NOT_EQUAL, BOOL, BOOL, null)
-    val BOOL_NOT = registerPrefixOp(Symbol.NOT, BOOL, BOOL, null)
-    val BOOL_OR = registerInfixOp(Symbol.OR, BOOL, BOOL, null)
-    val BOOL_XOR = registerInfixOp(Symbol.XOR, BOOL, BOOL, null)
+    val BOOL_TYPE = typeOf(BOOL)
+    val BOOL_AND = registerInfixOp(Symbol.AND, BOOL_TYPE, BOOL_TYPE, null)
+    val BOOL_EQ = registerInfixOp(Symbol.EQUAL, BOOL_TYPE, BOOL_TYPE, null)
+    val BOOL_NE = registerInfixOp(Symbol.NOT_EQUAL, BOOL_TYPE, BOOL_TYPE, null)
+    val BOOL_NOT = registerPrefixOp(Symbol.NOT, BOOL_TYPE, BOOL_TYPE, null)
+    val BOOL_OR = registerInfixOp(Symbol.OR, BOOL_TYPE, BOOL_TYPE, null)
+    val BOOL_XOR = registerInfixOp(Symbol.XOR, BOOL_TYPE, BOOL_TYPE, null)
     
     val INT32 = registerStruct(INT32_TYPE_NAME)
-    val INT32_LIT = registerLiteral(INT32_LIT_NAME, INT32)
-    val INT32_EQ = registerInfixOp(Symbol.EQUAL, INT32, BOOL, null)
-    val INT32_GE = registerInfixOp(Symbol.GREATER_EQUAL, INT32, BOOL, null)
-    val INT32_GT = registerInfixOp(Symbol.GREATER, INT32, BOOL, null)
-    val INT32_LE = registerInfixOp(Symbol.LESS_EQUAL, INT32, BOOL, null)
-    val INT32_LT = registerInfixOp(Symbol.LESS, INT32, BOOL, null)
-    val INT32_NE = registerInfixOp(Symbol.NOT_EQUAL, INT32, BOOL, null)
-    val INT32_ADD = registerInfixOp(Symbol.PLUS, INT32, INT32, VOID)
-    val INT32_DIV = registerInfixOp(Symbol.DIVIDE, INT32, INT32, VOID)
-    val INT32_MOD = registerInfixOp(Symbol.MODULO, INT32, INT32, VOID)
-    val INT32_MUL = registerInfixOp(Symbol.MULTIPLY, INT32, INT32, VOID)
-    val INT32_NEG = registerPrefixOp(Symbol.MINUS, INT32, INT32, VOID)
-    val INT32_POS = registerPrefixOp(Symbol.PLUS, INT32, INT32, VOID)
-    val INT32_SUB = registerInfixOp(Symbol.MINUS, INT32, INT32, VOID)
+    val INT32_TYPE = typeOf(INT32)
+    val INT32_LIT = registerLiteral(INT32_LIT_NAME, INT32_TYPE)
+    val INT32_EQ = registerInfixOp(Symbol.EQUAL, INT32_TYPE, BOOL_TYPE, null)
+    val INT32_GE = registerInfixOp(Symbol.GREATER_EQUAL, INT32_TYPE, BOOL_TYPE, null)
+    val INT32_GT = registerInfixOp(Symbol.GREATER, INT32_TYPE, BOOL_TYPE, null)
+    val INT32_LE = registerInfixOp(Symbol.LESS_EQUAL, INT32_TYPE, BOOL_TYPE, null)
+    val INT32_LT = registerInfixOp(Symbol.LESS, INT32_TYPE, BOOL_TYPE, null)
+    val INT32_NE = registerInfixOp(Symbol.NOT_EQUAL, INT32_TYPE, BOOL_TYPE, null)
+    val INT32_ADD = registerInfixOp(Symbol.PLUS, INT32_TYPE, INT32_TYPE, VOID_TYPE)
+    val INT32_DIV = registerInfixOp(Symbol.DIVIDE, INT32_TYPE, INT32_TYPE, VOID_TYPE)
+    val INT32_MOD = registerInfixOp(Symbol.MODULO, INT32_TYPE, INT32_TYPE, VOID_TYPE)
+    val INT32_MUL = registerInfixOp(Symbol.MULTIPLY, INT32_TYPE, INT32_TYPE, VOID_TYPE)
+    val INT32_NEG = registerPrefixOp(Symbol.MINUS, INT32_TYPE, INT32_TYPE, VOID_TYPE)
+    val INT32_POS = registerPrefixOp(Symbol.PLUS, INT32_TYPE, INT32_TYPE, VOID_TYPE)
+    val INT32_SUB = registerInfixOp(Symbol.MINUS, INT32_TYPE, INT32_TYPE, VOID_TYPE)
     
     val INT64 = registerStruct(INT64_TYPE_NAME)
-    val INT64_LIT = registerLiteral(INT64_LIT_NAME, INT64)
-    val INT64_EQ = registerInfixOp(Symbol.EQUAL, INT64, BOOL, null)
-    val INT64_GE = registerInfixOp(Symbol.GREATER_EQUAL, INT64, BOOL, null)
-    val INT64_GT = registerInfixOp(Symbol.GREATER, INT64, BOOL, null)
-    val INT64_LE = registerInfixOp(Symbol.LESS_EQUAL, INT64, BOOL, null)
-    val INT64_LT = registerInfixOp(Symbol.LESS, INT64, BOOL, null)
-    val INT64_NE = registerInfixOp(Symbol.NOT_EQUAL, INT64, BOOL, null)
-    val INT64_ADD = registerInfixOp(Symbol.PLUS, INT64, INT64, VOID)
-    val INT64_DIV = registerInfixOp(Symbol.DIVIDE, INT64, INT64, VOID)
-    val INT64_MOD = registerInfixOp(Symbol.MODULO, INT64, INT64, VOID)
-    val INT64_MUL = registerInfixOp(Symbol.MULTIPLY, INT64, INT64, VOID)
-    val INT64_NEG = registerPrefixOp(Symbol.MINUS, INT64, INT64, VOID)
-    val INT64_POS = registerPrefixOp(Symbol.PLUS, INT64, INT64, VOID)
-    val INT64_SUB = registerInfixOp(Symbol.MINUS, INT64, INT64, VOID)
+    val INT64_TYPE = typeOf(INT64)
+    val INT64_LIT = registerLiteral(INT64_LIT_NAME, INT64_TYPE)
+    val INT64_EQ = registerInfixOp(Symbol.EQUAL, INT64_TYPE, BOOL_TYPE, null)
+    val INT64_GE = registerInfixOp(Symbol.GREATER_EQUAL, INT64_TYPE, BOOL_TYPE, null)
+    val INT64_GT = registerInfixOp(Symbol.GREATER, INT64_TYPE, BOOL_TYPE, null)
+    val INT64_LE = registerInfixOp(Symbol.LESS_EQUAL, INT64_TYPE, BOOL_TYPE, null)
+    val INT64_LT = registerInfixOp(Symbol.LESS, INT64_TYPE, BOOL_TYPE, null)
+    val INT64_NE = registerInfixOp(Symbol.NOT_EQUAL, INT64_TYPE, BOOL_TYPE, null)
+    val INT64_ADD = registerInfixOp(Symbol.PLUS, INT64_TYPE, INT64_TYPE, VOID_TYPE)
+    val INT64_DIV = registerInfixOp(Symbol.DIVIDE, INT64_TYPE, INT64_TYPE, VOID_TYPE)
+    val INT64_MOD = registerInfixOp(Symbol.MODULO, INT64_TYPE, INT64_TYPE, VOID_TYPE)
+    val INT64_MUL = registerInfixOp(Symbol.MULTIPLY, INT64_TYPE, INT64_TYPE, VOID_TYPE)
+    val INT64_NEG = registerPrefixOp(Symbol.MINUS, INT64_TYPE, INT64_TYPE, VOID_TYPE)
+    val INT64_POS = registerPrefixOp(Symbol.PLUS, INT64_TYPE, INT64_TYPE, VOID_TYPE)
+    val INT64_SUB = registerInfixOp(Symbol.MINUS, INT64_TYPE, INT64_TYPE, VOID_TYPE)
     
     // TODO: Support strings somehow
     val STR = registerStruct(STR_TYPE_NAME)
-    val STR_LIT = registerLiteral(STR_LIT_NAME, VOID)
+    val STR_TYPE = typeOf(STR)
+    val STR_LIT = registerLiteral(STR_LIT_NAME, STR_TYPE)
 }
+
+/**
+ * Generates a type based on the [struct].
+ */
+private fun typeOf(struct: HirStruct) =
+    HirTypeStruct(name = struct.name, generics = emptyList(), mutability = Mutability.IMMUTABLE)
 
 /**
  * Registers a new type with the given [name].
@@ -82,27 +94,31 @@ private fun registerStruct(name: String) = HirStruct(
 ).also(Builtin.GLOBAL_SCOPE::register)
 
 /**
- * Defines a new literal with the given [name] and [type].
+ * Defines a new literal with the given [name] and [parameter]. The literal will return the same type as the parameter
+ * itself.
  */
-private fun registerLiteral(name: String, type: HirStruct) = HirLiteral(
+private fun registerLiteral(name: String, parameter: HirTypeStruct) = HirLiteral(
     id = UUID.randomUUID(),
     name = name,
-    value = HirTypeStruct(type.name, emptyList(), Mutability.IMMUTABLE),
+    type = HirTypeLiteral(value = parameter, parameter = parameter),
     visibility = Visibility.EXPORTED,
     instructions = emptyList(),
     variables = emptyList(),
-    parameter = paramOf("value", type),
+    parameter = paramOf("raw", parameter),
 ).also(Builtin.GLOBAL_SCOPE::register)
 
 /**
  * Defines a new infix operator for the given [operator]. The [parameter] type will be the same for both the left- and
  * the right-hand side expressions. The operator returns a value of the given [value] and [error] types.
  */
-private fun registerInfixOp(operator: Symbol, parameter: HirStruct, value: HirStruct, error: HirStruct?) = HirFunction(
+private fun registerInfixOp(operator: Symbol, parameter: HirType, value: HirType, error: HirType?) = HirFunction(
     id = UUID.randomUUID(),
     name = operator.symbol,
-    value = HirTypeStruct(value.name, emptyList(), Mutability.IMMUTABLE),
-    error = error?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    type = HirTypeFunction(
+        value = value,
+        error = error,
+        parameters = listOf(HirTypedParameter("lhs", parameter), HirTypedParameter("rhs", parameter)),
+    ),
     visibility = Visibility.EXPORTED,
     instructions = emptyList(),
     generics = emptyList(),
@@ -114,11 +130,14 @@ private fun registerInfixOp(operator: Symbol, parameter: HirStruct, value: HirSt
  * Defines a new prefix operator for the given [operator]. The [parameter] type determines which expressions are legal.
  * The operator returns a value of the given [value] and [error] types.
  */
-private fun registerPrefixOp(operator: Symbol, parameter: HirStruct, value: HirStruct, error: HirStruct?) = HirFunction(
+private fun registerPrefixOp(operator: Symbol, parameter: HirType, value: HirType, error: HirType?) = HirFunction(
     id = UUID.randomUUID(),
     name = operator.symbol,
-    value = HirTypeStruct(value.name, emptyList(), Mutability.IMMUTABLE),
-    error = error?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    type = HirTypeFunction(
+        value = value,
+        error = error,
+        parameters = listOf(HirTypedParameter("rhs", parameter)),
+    ),
     visibility = Visibility.EXPORTED,
     instructions = emptyList(),
     generics = emptyList(),
@@ -129,10 +148,10 @@ private fun registerPrefixOp(operator: Symbol, parameter: HirStruct, value: HirS
 /**
  * Defines a new function parameter of the given [type].
  */
-private fun paramOf(name: String, type: HirStruct) = HirParameter(
+private fun paramOf(name: String, type: HirType) = HirParameter(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeStruct(type.name, emptyList(), Mutability.IMMUTABLE),
+    type = type,
     value = null,
     passability = Passability.IN,
 )

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Metadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Metadata.kt
@@ -12,7 +12,6 @@ sealed interface HirType
 /**
  * The struct type describes a concrete type by [name], which may be specialized with any number of [generics].
  */
-// TODO: Is this needed?
 data class HirTypeStruct(
     val name: String,
     val generics: List<HirTypedParameter>,
@@ -23,7 +22,6 @@ data class HirTypeStruct(
  * The function type describes a function returning a [value] and [error] type, with any number of [parameters]. The
  * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
  */
-// TODO: Is this needed?
 data class HirTypeFunction(
     val value: HirType?,
     val error: HirType?,
@@ -37,7 +35,7 @@ data class HirTypeFunction(
 // TODO: Is this needed?
 data class HirTypeLiteral(
     val value: HirType,
-    val parameter: HirTypeStruct,
+    val parameter: HirType,
 ) : HirType
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
@@ -78,8 +78,7 @@ data class HirConcept(
 data class HirFunction(
     override val id: UUID,
     override val name: String,
-    val value: HirType?,
-    val error: HirType?,
+    val type: HirTypeFunction,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     
@@ -96,9 +95,7 @@ data class HirFunction(
 data class HirMethod(
     override val id: UUID,
     override val name: String,
-    val type: HirType,
-    val value: HirType?,
-    val error: HirType?,
+    val type: HirTypeFunction,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     
@@ -115,7 +112,7 @@ data class HirMethod(
 data class HirLiteral(
     override val id: UUID,
     override val name: String,
-    val value: HirType,
+    val type: HirTypeLiteral,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -54,14 +54,17 @@ infix fun HirVariable.hirAssign(that: Any) = HirAssign(hirLoad, that.hir)
 
 fun hirFunOf(
     name: String = UUID.randomUUID().toString(),
-    value: HirStruct? = null,
-    error: HirStruct? = null,
+    value: HirType? = null,
+    error: HirType? = null,
     params: List<HirParameter> = emptyList(),
 ) = HirFunction(
     id = UUID.randomUUID(),
     name = name,
-    value = value?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
-    error = error?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    type = HirTypeFunction(
+        value = value,
+        error = error,
+        parameters = params.map { HirTypedParameter(it.name, it.type) },
+    ),
     visibility = Visibility.PRIVATE,
     instructions = emptyList(),
     generics = emptyList(),
@@ -71,12 +74,12 @@ fun hirFunOf(
 
 fun hirLitOf(
     name: String = UUID.randomUUID().toString(),
-    value: HirStruct = Builtin.VOID,
-    param: HirParameter = hirParamOf(type = Builtin.INT32),
+    value: HirType = Builtin.INT32_TYPE,
+    param: HirParameter = hirParamOf(),
 ) = HirLiteral(
     id = UUID.randomUUID(),
     name = name,
-    value = HirTypeStruct(value.name, emptyList(), Mutability.IMMUTABLE),
+    type = HirTypeLiteral(value = value, parameter = param.type),
     visibility = Visibility.PRIVATE,
     instructions = emptyList(),
     variables = emptyList(),
@@ -85,24 +88,24 @@ fun hirLitOf(
 
 fun hirParamOf(
     name: String = UUID.randomUUID().toString(),
-    type: HirStruct = Builtin.VOID,
+    type: HirType = Builtin.INT32_TYPE,
     value: HirValue? = null,
 ) = HirParameter(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeStruct(type.name, emptyList(), Mutability.IMMUTABLE),
+    type = type,
     value = value,
     passability = Passability.IN,
 )
 
 fun hirVarOf(
     name: String = UUID.randomUUID().toString(),
-    type: HirStruct? = null,
+    type: HirType? = null,
     value: Any = 0,
 ) = HirVariable(
     id = UUID.randomUUID(),
     name = name,
-    type = type?.let { HirTypeStruct(it.name, emptyList(), Mutability.IMMUTABLE) },
+    type = type,
     value = value.hir,
     assignability = Assignability.FINAL,
 )


### PR DESCRIPTION
Here we make the type of functions and literals explicit, by moving the value, error, and parameter type information into a single construct. The net outcome is a simpler data structure to reason around, and which will greatly simplify type resolution in a later pull request.