### PR TITLE
124 introduce union types

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverTypes.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverTypes.kt
@@ -48,18 +48,9 @@ internal class ResolverType(private val scope: Scope)
     
     fun resolve(type: HirTypeUnion): Result<ThirType, ResolveError>
     {
-        // We require at least one entry in the union, otherwise we do not really have anything to go by. In the case of
-        // a single entry, we can also simplify the union to that one entry, reducing nesting.
-        val types = when (type.types.size)
-        {
-            0    -> return ResolveError.Placeholder.toFailure() // TODO: Replace me with a proper error.
-            1    -> return resolve(type.types.single())
-            else -> type.types.mapUntilError { resolve(it) }.valueOr { return it.toFailure() }
-        }
+        val types = type.types.mapUntilError { resolve(it) }.valueOr { return it.toFailure() }
         
-        // If we have any unions within our union, we can simplify the entire set of types to no nested unions.
-        val simplified = types.flatMap { if (it is ThirTypeUnion) it.types else setOf(it) }
-        return ThirTypeUnion(simplified.toSet()).toSuccess()
+        return ThirTypeUnion(types).toSuccess()
     }
     
     private fun handle(type: Named<HirType>): Result<Named<ThirType>, ResolveError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
@@ -117,6 +117,7 @@ internal class ResolverValue(private val types: TypeTable, private val scope: Sc
         // We must have at least one symbol which can be considered a callable at this point. We need to examine every
         // single symbol that is within scope, as callables can come in many forms. Due to overload resolution, we need
         // to examine every candidate, to make sure there is no ambiguity or mismatches.
+        // TODO: Support callables which are stored in variables, parameters, etc.
         val functions = scope.resolve<HirFunction>(node.instance.name)
         if (functions.isEmpty())
             return ResolveError.UnknownFunction(node.instance.name).toFailure()

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
@@ -23,7 +23,7 @@ data class HirTypeData(val name: String, val mutability: Mutability, val generic
 data class HirTypeCall(val value: HirType?, val error: HirType?, val parameters: List<Named<HirType>>) : HirType
 
 /**
- * The union type describes a type which is exactly one of the specified [types]. Any type can be in a union with a
- * union type, although the set of potential types is collapsed into a single set.
+ * The union type describes a type which is one of the specified [types]. Any type can be in a union with a union type,
+ * although the set of potential types is collapsed into a single set.
  */
-data class HirTypeUnion(val types: Set<HirType>) : HirType
+data class HirTypeUnion(val types: List<HirType>) : HirType

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
@@ -21,3 +21,9 @@ data class HirTypeData(val name: String, val mutability: Mutability, val generic
  * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
  */
 data class HirTypeCall(val value: HirType?, val error: HirType?, val parameters: List<Named<HirType>>) : HirType
+
+/**
+ * The union type describes a type which is exactly one of the specified [types]. Any type can be in a union with a
+ * union type, although the set of potential types is collapsed into a single set.
+ */
+data class HirTypeUnion(val types: Set<HirType>) : HirType

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
@@ -23,7 +23,7 @@ data class ThirTypeData(val symbolId: UUID, val mutability: Mutability, val gene
 data class ThirTypeCall(val value: ThirType?, val error: ThirType?, val parameters: List<Named<ThirType>>) : ThirType
 
 /**
- * The union type describes a type which is exactly one of the specified [types]. Any type can be in a union with a
- * union type, although the set of potential types is collapsed into a single set.
+ * The union type describes a type which is one of the specified [types]. Any type can be in a union with a union type,
+ * although the set of potential types is collapsed into a single set.
  */
-data class ThirTypeUnion(val types: Set<ThirType>) : ThirType
+data class ThirTypeUnion(val types: List<ThirType>) : ThirType

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
@@ -21,3 +21,9 @@ data class ThirTypeData(val symbolId: UUID, val mutability: Mutability, val gene
  * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
  */
 data class ThirTypeCall(val value: ThirType?, val error: ThirType?, val parameters: List<Named<ThirType>>) : ThirType
+
+/**
+ * The union type describes a type which is exactly one of the specified [types]. Any type can be in a union with a
+ * union type, although the set of potential types is collapsed into a single set.
+ */
+data class ThirTypeUnion(val types: Set<ThirType>) : ThirType

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverTypes.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverTypes.kt
@@ -7,8 +7,6 @@ import com.github.derg.transpiler.source.hir.Builtin.BOOL
 import com.github.derg.transpiler.source.hir.Builtin.BOOL_TYPE
 import com.github.derg.transpiler.source.hir.Builtin.INT32
 import com.github.derg.transpiler.source.hir.Builtin.INT32_TYPE
-import com.github.derg.transpiler.source.hir.Builtin.INT64
-import com.github.derg.transpiler.source.hir.Builtin.INT64_TYPE
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 import org.junit.jupiter.api.*
@@ -100,17 +98,18 @@ class TestResolverType
     inner class Union
     {
         @Test
-        fun `Given empty, when resolving, then correct error`()
+        fun `Given empty, when resolving, then correct outcome`()
         {
-            val expected = Placeholder
+            val expected = ThirTypeUnion(emptyList())
             
-            assertFailure(expected, resolver.resolve(hirTypeUnion()))
+            assertSuccess(expected, resolver.resolve(hirTypeUnion()))
         }
         
         @Test
         fun `Given single, when resolving, then correct outcome`()
         {
-            val expected = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            val inner = listOf(ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()))
+            val expected = ThirTypeUnion(inner)
             
             assertSuccess(expected, resolver.resolve(hirTypeUnion(BOOL_TYPE)))
         }
@@ -118,7 +117,7 @@ class TestResolverType
         @Test
         fun `Given multiple, when resolving, then correct outcome`()
         {
-            val inner = setOf(
+            val inner = listOf(
                 ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()),
                 ThirTypeData(INT32.id, Mutability.IMMUTABLE, emptyList()),
             )
@@ -130,22 +129,10 @@ class TestResolverType
         @Test
         fun `Given nested, when resolving, then correct outcome`()
         {
-            val expected = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            val inner = listOf(ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()))
+            val expected = ThirTypeUnion(listOf(ThirTypeUnion(inner)))
             
             assertSuccess(expected, resolver.resolve(hirTypeUnion(hirTypeUnion(BOOL_TYPE))))
-        }
-        
-        @Test
-        fun `Given union, when resolving, then correct outcome`()
-        {
-            val inner = setOf(
-                ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()),
-                ThirTypeData(INT32.id, Mutability.IMMUTABLE, emptyList()),
-                ThirTypeData(INT64.id, Mutability.IMMUTABLE, emptyList()),
-            )
-            val expected = ThirTypeUnion(inner)
-            
-            assertSuccess(expected, resolver.resolve(hirTypeUnion(BOOL_TYPE, hirTypeUnion(INT32_TYPE, INT64_TYPE))))
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverTypes.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverTypes.kt
@@ -5,6 +5,10 @@ import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.hir.Builtin.BOOL
 import com.github.derg.transpiler.source.hir.Builtin.BOOL_TYPE
+import com.github.derg.transpiler.source.hir.Builtin.INT32
+import com.github.derg.transpiler.source.hir.Builtin.INT32_TYPE
+import com.github.derg.transpiler.source.hir.Builtin.INT64
+import com.github.derg.transpiler.source.hir.Builtin.INT64_TYPE
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 import org.junit.jupiter.api.*
@@ -89,6 +93,59 @@ class TestResolverType
             val expected = ThirTypeCall(null, null, listOf("" to param))
             
             assertSuccess(expected, resolver.resolve(hirTypeCall(parameters = listOf(BOOL_TYPE))))
+        }
+    }
+    
+    @Nested
+    inner class Union
+    {
+        @Test
+        fun `Given empty, when resolving, then correct error`()
+        {
+            val expected = Placeholder
+            
+            assertFailure(expected, resolver.resolve(hirTypeUnion()))
+        }
+        
+        @Test
+        fun `Given single, when resolving, then correct outcome`()
+        {
+            val expected = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            
+            assertSuccess(expected, resolver.resolve(hirTypeUnion(BOOL_TYPE)))
+        }
+        
+        @Test
+        fun `Given multiple, when resolving, then correct outcome`()
+        {
+            val inner = setOf(
+                ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()),
+                ThirTypeData(INT32.id, Mutability.IMMUTABLE, emptyList()),
+            )
+            val expected = ThirTypeUnion(inner)
+            
+            assertSuccess(expected, resolver.resolve(hirTypeUnion(BOOL_TYPE, INT32_TYPE)))
+        }
+        
+        @Test
+        fun `Given nested, when resolving, then correct outcome`()
+        {
+            val expected = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            
+            assertSuccess(expected, resolver.resolve(hirTypeUnion(hirTypeUnion(BOOL_TYPE))))
+        }
+        
+        @Test
+        fun `Given union, when resolving, then correct outcome`()
+        {
+            val inner = setOf(
+                ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()),
+                ThirTypeData(INT32.id, Mutability.IMMUTABLE, emptyList()),
+                ThirTypeData(INT64.id, Mutability.IMMUTABLE, emptyList()),
+            )
+            val expected = ThirTypeUnion(inner)
+            
+            assertSuccess(expected, resolver.resolve(hirTypeUnion(BOOL_TYPE, hirTypeUnion(INT32_TYPE, INT64_TYPE))))
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
@@ -303,8 +303,7 @@ class TestResolverValue
         @Test
         fun `Given unknown overload, when resolving, then correct error`()
         {
-            val expected =
-                ArgumentMismatch(Symbol.GREATER_EQUAL.symbol, listOf(null hirArg true, null hirArg false))
+            val expected = ArgumentMismatch(Symbol.GREATER_EQUAL.symbol, listOf(null hirArg true, null hirArg false))
             
             assertFailure(expected, run(true hirGe false))
         }

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -51,6 +51,8 @@ fun hirTypeCall(
     parameters = parameters.map { "" to it },
 )
 
+fun hirTypeUnion(vararg types: HirType) = HirTypeUnion(types.toSet())
+
 ////////////////////////
 // Expression helpers //
 ////////////////////////

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -51,7 +51,7 @@ fun hirTypeCall(
     parameters = parameters.map { "" to it },
 )
 
-fun hirTypeUnion(vararg types: HirType) = HirTypeUnion(types.toSet())
+fun hirTypeUnion(vararg types: HirType) = HirTypeUnion(types.toList())
 
 ////////////////////////
 // Expression helpers //


### PR DESCRIPTION
This pull request introduces a super-simple initial proposal for union types. The union type represents a type which can hold exactly one of any number of specified types. As an example, a union type of `bool`, `int32`, and `int64` can store any value of the mentioned types, but cannot store i.e. `str`.