### PR TITLE
129 implement type checker for branching

### DIFF
--- a/docs/statements.md
+++ b/docs/statements.md
@@ -1,0 +1,44 @@
+# Statements
+
+## Control flow
+
+### Branch
+
+The branching statement allows the execution flow of the program to be controlled via a predicate. Whenever the
+condition evaluates to `true`, the success branch is followed. Otherwise, the failure branch is. The execution flow will
+only take one of the two branches, never both.
+
+Branches are declared using the `if` keyword, and require an expression which must evaluate to a boolean value. The
+success branch is required, and may contain any number of instructions in it. The failure branch is optional, and is
+declared using the `else` keyword. Note that the branches should never contain zero statements, although the language
+does not restrict the number. When zero or more than one instruction is present within any branch, the instructions must
+be enclosed in brackets (`{´ and `}`).
+
+Examples:
+
+```derg
+// Simplest form, if the condition evaluates to true, the statement is executed.
+if condition
+    statement
+
+// A failure branch which will be executed if the condition evaluates to false.
+if condition
+    success
+else
+    failure
+
+// Multiple conditionals chained together, exactly one branch will be executed.
+if condition_1
+    statement_1
+else if condition_2
+    statement_2
+else
+    statement_3
+
+// Multiple statements within a single branch.
+if condition
+{
+    statement_1
+    statement_2
+}
+```

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -1,0 +1,20 @@
+package com.github.derg.transpiler.phases.typechecker
+
+import com.github.derg.transpiler.source.thir.*
+
+/**
+ * During the type checking phase, a variety of type errors may arise. These errors describe why a type cannot be used
+ * in the place the developer has attempted.
+ */
+sealed interface TypeError
+{
+    /**
+     * The provided [value] did not evaluate to a boolean type, which is required by the branch predicate.
+     */
+    data class BranchPredicateNotBool(val value: ThirValue) : TypeError
+    
+    /**
+     * The branch predicate contains an [error] type which is not permitted. Predicates must always succeed.
+     */
+    data class BranchPredicateHasError(val error: ThirValue) : TypeError
+}

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -1,0 +1,32 @@
+package com.github.derg.transpiler.phases.typechecker
+
+import com.github.derg.transpiler.source.hir.*
+import com.github.derg.transpiler.source.thir.*
+import com.github.derg.transpiler.utils.*
+
+/**
+ * Performs type-checking on the instruction [node]. If there are any type errors detected, an error is returned.
+ */
+internal fun check(node: ThirInstruction): Result<Unit, TypeError> = when (node)
+{
+    is ThirAssign      -> TODO()
+    is ThirBranch      -> handle(node)
+    is ThirEvaluate    -> TODO()
+    is ThirReturn      -> TODO()
+    is ThirReturnError -> TODO()
+    is ThirReturnValue -> TODO()
+}
+
+private fun handle(node: ThirBranch): Result<Unit, TypeError>
+{
+    // Predicates are not permitted to contain error types.
+    if (node.predicate.error != null)
+        return TypeError.BranchPredicateHasError(node.predicate).toFailure()
+    
+    // The value type must be boolean.
+    val value = node.predicate.value as? ThirTypeData
+    if (value == null || value.symbolId != Builtin.BOOL.id)
+        return TypeError.BranchPredicateNotBool(node.predicate).toFailure()
+    
+    return Unit.toSuccess()
+}

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -1,0 +1,44 @@
+package com.github.derg.transpiler.phases.typechecker
+
+import com.github.derg.transpiler.source.hir.*
+import com.github.derg.transpiler.source.thir.*
+import com.github.derg.transpiler.utils.*
+import org.junit.jupiter.api.*
+
+class TestCheckerInstructions
+{
+    @Nested
+    inner class Branch
+    {
+        @Test
+        fun `Given valid value type, when checking, then correct outcome`()
+        {
+            assertSuccess(Unit, check(true.thirBranch()))
+        }
+        
+        @Test
+        fun `Given invalid value type, when checking, then correct error`()
+        {
+            val expected = TypeError.BranchPredicateNotBool(0.thir)
+            
+            assertFailure(expected, check(0.thirBranch()))
+        }
+        
+        @Test
+        fun `Given valid error type, when checking, then correct outcome`()
+        {
+            val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = null).thirCall()
+            
+            assertSuccess(Unit, check(input.thirBranch()))
+        }
+        
+        @Test
+        fun `Given invalid error type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = thirTypeData()).thirCall()
+            val expected = TypeError.BranchPredicateHasError(input)
+            
+            assertFailure(expected, check(input.thirBranch()))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -33,7 +33,7 @@ fun hirTypeData(
 )
 
 fun hirTypeData(
-    name: String,
+    name: String = UUID.randomUUID().toString(),
     mutability: Mutability = Mutability.IMMUTABLE,
 ) = HirTypeData(
     name = name,

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -17,6 +17,38 @@ val Any.thir: ThirValue
         else         -> throw IllegalArgumentException("Value $this does not represent a valid thir value")
     }
 
+//////////////////
+// Type helpers //
+//////////////////
+
+fun thirTypeData(
+    struct: ThirStruct,
+    mutability: Mutability = Mutability.IMMUTABLE,
+) = ThirTypeData(
+    symbolId = struct.id,
+    generics = emptyList(),
+    mutability = mutability,
+)
+
+fun thirTypeData(
+    symbolId: UUID = UUID.randomUUID(),
+    mutability: Mutability = Mutability.IMMUTABLE,
+) = ThirTypeData(
+    symbolId = symbolId,
+    generics = emptyList(),
+    mutability = mutability,
+)
+
+fun thirTypeCall(
+    value: ThirType? = null,
+    error: ThirType? = null,
+    parameters: List<ThirType> = emptyList(),
+) = ThirTypeCall(
+    value = value,
+    error = error,
+    parameters = parameters.map { "" to it },
+)
+
 ////////////////////////
 // Expression helpers //
 ////////////////////////


### PR DESCRIPTION
This pull request introduces a basic and super-rudimentary type-checker for branch predicates. The type-checker only verifies that the error type is absent, and that the value type is a boolean. The type-checker is not yet fully integrated into the compiler; it needs to be more fleshed out before we have any solid way to integrate it.