### PR TITLE
131 implement type-checker for evaluation statement

### DIFF
--- a/docs/statements.md
+++ b/docs/statements.md
@@ -42,3 +42,24 @@ if condition
     statement_2
 }
 ```
+
+### Evaluate
+
+The evaluate statement allows a piece of code to be executed for its side effects. When evaluating an expression, both
+the value type and error type of the expression must be absent. This has the consequence that expressions which evaluate
+to a value or an error, cannot be used as statements - any expression which produces a value, must be consumed. If the
+expression produces an error, the error must be handled.
+
+Some expressions naturally do not produce any value, such as a function call to the function which has no return value
+or error.
+
+Examples:
+
+```
+fun do_work() { /* Implementation omitted */ }
+fun make_it() -> Data { /* Implementation omitted */ }
+
+do_work() // Legal, function returns no value, nor does it raise any error.
+make_it() // Not legal, expression has a value type associated with it.
+9001      // Not legal, expression has a value type associated with it. 
+```

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
@@ -61,8 +61,8 @@ internal class ResolverInstruction(private val types: TypeTable, private val sco
     
     private fun handle(node: HirEvaluate): Result<ThirInstruction, ResolveError>
     {
-        val value = values.resolve(node.value).valueOr { return it.toFailure() }
+        val expression = values.resolve(node.expression).valueOr { return it.toFailure() }
         
-        return ThirEvaluate(value).toSuccess()
+        return ThirEvaluate(expression).toSuccess()
     }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -17,4 +17,14 @@ sealed interface TypeError
      * The branch predicate contains an [error] type which is not permitted. Predicates must always succeed.
      */
     data class BranchPredicateHasError(val error: ThirValue) : TypeError
+    
+    /**
+     * The provided [value] was evaluated to have a value type, which is not permitted.
+     */
+    data class EvaluateHasValue(val value: ThirValue): TypeError
+    
+    /**
+     * The provided [error] was evaluated to have a value type, which is not permitted.
+     */
+    data class EvaluateHasError(val error: ThirValue): TypeError
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -11,7 +11,7 @@ internal fun check(node: ThirInstruction): Result<Unit, TypeError> = when (node)
 {
     is ThirAssign      -> TODO()
     is ThirBranch      -> handle(node)
-    is ThirEvaluate    -> TODO()
+    is ThirEvaluate    -> handle(node)
     is ThirReturn      -> TODO()
     is ThirReturnError -> TODO()
     is ThirReturnValue -> TODO()
@@ -27,6 +27,19 @@ private fun handle(node: ThirBranch): Result<Unit, TypeError>
     val value = node.predicate.value as? ThirTypeData
     if (value == null || value.symbolId != Builtin.BOOL.id)
         return TypeError.BranchPredicateNotBool(node.predicate).toFailure()
+    
+    return Unit.toSuccess()
+}
+
+private fun handle(node: ThirEvaluate): Result<Unit, TypeError>
+{
+    // Evaluations are not permitted to contain error types.
+    if (node.expression.error != null)
+        return TypeError.EvaluateHasError(node.expression).toFailure()
+    
+    // Evaluations are not permitted to contain value types.
+    if (node.expression.value != null)
+        return TypeError.EvaluateHasValue(node.expression).toFailure()
     
     return Unit.toSuccess()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
@@ -22,10 +22,10 @@ data class HirBranch(
 ) : HirInstruction
 
 /**
- * Evaluates the [value], and executes any side effects which may arise as a consequence. The [value] is not permitted
- * to evaluate to any non-void value or error.
+ * Evaluates the [expression], and executes any side effects which may arise as a consequence. The [expression] is not
+ * permitted to evaluate to any non-void value or error.
  */
-data class HirEvaluate(val value: HirValue) : HirInstruction
+data class HirEvaluate(val expression: HirValue) : HirInstruction
 
 /**
  * Exist the current function call, returning control flow to whoever called the function in the first place.

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
@@ -24,10 +24,10 @@ data class ThirBranch(
 ) : ThirInstruction
 
 /**
- * Evaluates the [value], executes any side effects which may arise as a consequence. The value and error returned from
+ * Evaluates the [expression], executes any side effects which may arise as a consequence. The value and error returned from
  * the invocation must resolve to void.
  */
-data class ThirEvaluate(val value: ThirValue) : ThirInstruction
+data class ThirEvaluate(val expression: ThirValue) : ThirInstruction
 
 /**
  * Exist the current function call, returning control flow to whoever called the function in the first place.

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -11,25 +11,20 @@ class TestCheckerInstructions
     inner class Branch
     {
         @Test
-        fun `Given valid value type, when checking, then correct outcome`()
+        fun `Given valid type, when checking, then correct outcome`()
         {
-            assertSuccess(Unit, check(true.thirBranch()))
+            val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = null).thirCall()
+            
+            assertSuccess(Unit, check(input.thirBranch()))
         }
         
         @Test
         fun `Given invalid value type, when checking, then correct error`()
         {
-            val expected = TypeError.BranchPredicateNotBool(0.thir)
+            val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
+            val expected = TypeError.BranchPredicateNotBool(input)
             
-            assertFailure(expected, check(0.thirBranch()))
-        }
-        
-        @Test
-        fun `Given valid error type, when checking, then correct outcome`()
-        {
-            val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = null).thirCall()
-            
-            assertSuccess(Unit, check(input.thirBranch()))
+            assertFailure(expected, check(input.thirBranch()))
         }
         
         @Test
@@ -39,6 +34,36 @@ class TestCheckerInstructions
             val expected = TypeError.BranchPredicateHasError(input)
             
             assertFailure(expected, check(input.thirBranch()))
+        }
+    }
+    
+    @Nested
+    inner class Evaluate
+    {
+        @Test
+        fun `Given valid type, when checking, then correct outcome`()
+        {
+            val input = thirFunOf(value = null, error = null).thirCall()
+            
+            assertSuccess(Unit, check(input.thirEval))
+        }
+        
+        @Test
+        fun `Given invalid value type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
+            val expected = TypeError.EvaluateHasValue(input)
+            
+            assertFailure(expected, check(input.thirEval))
+        }
+        
+        @Test
+        fun `Given invalid error type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = null, error = thirTypeData()).thirCall()
+            val expected = TypeError.EvaluateHasError(input)
+            
+            assertFailure(expected, check(input.thirEval))
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -92,7 +92,7 @@ infix fun String?.hirArg(that: Any) = NamedMaybe(this, that.hir)
 
 infix fun HirVariable.hirAssign(that: Any) = HirAssign(hirLoad, that.hir)
 
-val HirValue.hirEval get() = HirEvaluate(this)
+val Any.hirEval get() = HirEvaluate(hir)
 val Any.hirReturnError get() = HirReturnError(hir)
 val Any.hirReturnValue get() = HirReturnValue(hir)
 

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -102,7 +102,7 @@ fun ThirFunction.thirCall(vararg parameters: Any) = ThirCall(type.value, type.er
 
 infix fun ThirVariable.thirAssign(that: Any) = ThirAssign(id, that.thir)
 
-val ThirValue.thirEval get() = ThirEvaluate(this)
+val Any.thirEval get() = ThirEvaluate(thir)
 val Any.thirReturnError get() = ThirReturnError(thir)
 val Any.thirReturnValue get() = ThirReturnValue(thir)
 


### PR DESCRIPTION
I this pull request, we introduce basic type-checker logic to verify that evaluation statements have no value or error type. This ensures that we never lose a value that must be consumed, nor that we forget an error that must be handled.