### PR TITLE
133 implement type checker for return statements

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
@@ -27,8 +27,8 @@ internal class ResolverInstruction(private val types: TypeTable, private val sco
         is HirBranch      -> handle(node)
         is HirEvaluate    -> handle(node)
         is HirReturn      -> ThirReturn.toSuccess()
-        is HirReturnError -> values.resolve(node.value).mapValue { ThirReturnError(it) }
-        is HirReturnValue -> values.resolve(node.value).mapValue { ThirReturnValue(it) }
+        is HirReturnError -> values.resolve(node.expression).mapValue { ThirReturnError(it) }
+        is HirReturnValue -> values.resolve(node.expression).mapValue { ThirReturnValue(it) }
     }
     
     private fun handle(node: HirAssign): Result<ThirInstruction, ResolveError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -9,24 +9,24 @@ import com.github.derg.transpiler.source.thir.*
 sealed interface TypeError
 {
     /**
-     * The provided [value] did not evaluate to a boolean type, which is required by the branch predicate.
+     * The branch [predicate] did not evaluate to a boolean type, which is required by the branch predicate.
      */
-    data class BranchPredicateNotBool(val value: ThirValue) : TypeError
+    data class BranchWrongValue(val predicate: ThirValue) : TypeError
     
     /**
-     * The branch predicate contains an [error] type which is not permitted. Predicates must always succeed.
+     * The branch [predicate] is evaluated to a possible error type, which is not permitted.
      */
-    data class BranchPredicateHasError(val error: ThirValue) : TypeError
+    data class BranchHasError(val predicate: ThirValue) : TypeError
     
     /**
-     * The provided [value] was evaluated to have a value type, which is not permitted.
+     * The provided [expression] is evaluated to a possible value, which is not permitted.
      */
-    data class EvaluateHasValue(val value: ThirValue) : TypeError
+    data class EvaluateHasValue(val expression: ThirValue) : TypeError
     
     /**
-     * The provided [error] was evaluated to have a value type, which is not permitted.
+     * The provided [expression] is evaluated to a possible error, which is not permitted.
      */
-    data class EvaluateHasError(val error: ThirValue) : TypeError
+    data class EvaluateHasError(val expression: ThirValue) : TypeError
     
     /**
      * The return statement lacks a value associated with it, when the callable expected something to be returned.
@@ -39,22 +39,22 @@ sealed interface TypeError
     data object ReturnLacksError : TypeError
     
     /**
-     * The return statement has a [value] associated with it, when the callable expected nothing to be returned.
+     * The return statement has a [expression] which evaluates to a value, when no return value was expected.
      */
-    data class ReturnHasValue(val value: ThirValue) : TypeError
+    data class ReturnHasValue(val expression: ThirValue) : TypeError
     
     /**
-     * The return statement has an [error] associated with it, when the callable expected nothing to be raised.
+     * The return statement has an [expression] which evaluates to an error, when no return error was expected.
      */
-    data class ReturnHasError(val error: ThirValue) : TypeError
+    data class ReturnHasError(val expression: ThirValue) : TypeError
     
     /**
-     * The return statement has a [value] associated with it, when the callable expected a different return type.
+     * The return statement has an [expression] which evaluates to the wrong value type.
      */
-    data class ReturnWrongValue(val value: ThirValue) : TypeError
+    data class ReturnWrongValue(val expression: ThirValue) : TypeError
     
     /**
-     * The return statement has an [error] associated with it, when the callable expected a different raise type.
+     * The return statement has an [expression] which evaluates to the wrong error type.
      */
-    data class ReturnWrongError(val error: ThirValue) : TypeError
+    data class ReturnWrongError(val expression: ThirValue) : TypeError
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -21,10 +21,40 @@ sealed interface TypeError
     /**
      * The provided [value] was evaluated to have a value type, which is not permitted.
      */
-    data class EvaluateHasValue(val value: ThirValue): TypeError
+    data class EvaluateHasValue(val value: ThirValue) : TypeError
     
     /**
      * The provided [error] was evaluated to have a value type, which is not permitted.
      */
-    data class EvaluateHasError(val error: ThirValue): TypeError
+    data class EvaluateHasError(val error: ThirValue) : TypeError
+    
+    /**
+     * The return statement lacks a value associated with it, when the callable expected something to be returned.
+     */
+    data object ReturnLacksValue : TypeError
+    
+    /**
+     * The return statement lacks an error associated with it, when the callable expected something to be raised.
+     */
+    data object ReturnLacksError : TypeError
+    
+    /**
+     * The return statement has a [value] associated with it, when the callable expected nothing to be returned.
+     */
+    data class ReturnHasValue(val value: ThirValue) : TypeError
+    
+    /**
+     * The return statement has an [error] associated with it, when the callable expected nothing to be raised.
+     */
+    data class ReturnHasError(val error: ThirValue) : TypeError
+    
+    /**
+     * The return statement has a [value] associated with it, when the callable expected a different return type.
+     */
+    data class ReturnWrongValue(val value: ThirValue) : TypeError
+    
+    /**
+     * The return statement has an [error] associated with it, when the callable expected a different raise type.
+     */
+    data class ReturnWrongError(val error: ThirValue) : TypeError
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -5,41 +5,97 @@ import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 
 /**
- * Performs type-checking on the instruction [node]. If there are any type errors detected, an error is returned.
+ * The instruction checker ensures that all instructions within some callable context are valid. The instructions are expected to output the [value] and [error]
+ * types, if they are specified.
  */
-internal fun check(node: ThirInstruction): Result<Unit, TypeError> = when (node)
+internal class CheckerInstruction(private val value: ThirType?, private val error: ThirType?)
 {
-    is ThirAssign      -> TODO()
-    is ThirBranch      -> handle(node)
-    is ThirEvaluate    -> handle(node)
-    is ThirReturn      -> TODO()
-    is ThirReturnError -> TODO()
-    is ThirReturnValue -> TODO()
-}
-
-private fun handle(node: ThirBranch): Result<Unit, TypeError>
-{
-    // Predicates are not permitted to contain error types.
-    if (node.predicate.error != null)
-        return TypeError.BranchPredicateHasError(node.predicate).toFailure()
+    /**
+     * Performs type-checking on the instruction [node]. If there are any type errors detected, an error is returned.
+     */
+    fun check(node: ThirInstruction): Result<Unit, TypeError> = when (node)
+    {
+        is ThirAssign      -> TODO()
+        is ThirBranch      -> handle(node)
+        is ThirEvaluate    -> handle(node)
+        is ThirReturn      -> handle(node)
+        is ThirReturnError -> handle(node)
+        is ThirReturnValue -> handle(node)
+    }
     
-    // The value type must be boolean.
-    val value = node.predicate.value as? ThirTypeData
-    if (value == null || value.symbolId != Builtin.BOOL.id)
-        return TypeError.BranchPredicateNotBool(node.predicate).toFailure()
+    private fun handle(node: ThirBranch): Result<Unit, TypeError>
+    {
+        // Predicates are not permitted to contain error types.
+        if (node.predicate.error != null)
+            return TypeError.BranchPredicateHasError(node.predicate).toFailure()
+        
+        // The value type must be boolean.
+        val value = node.predicate.value as? ThirTypeData
+        if (value == null || value.symbolId != Builtin.BOOL.id)
+            return TypeError.BranchPredicateNotBool(node.predicate).toFailure()
+        
+        // TODO: Type-check the predicate too, ensure that it does not contain any forbidden values either.
+        return Unit.toSuccess()
+    }
     
-    return Unit.toSuccess()
-}
-
-private fun handle(node: ThirEvaluate): Result<Unit, TypeError>
-{
-    // Evaluations are not permitted to contain error types.
-    if (node.expression.error != null)
-        return TypeError.EvaluateHasError(node.expression).toFailure()
+    private fun handle(node: ThirEvaluate): Result<Unit, TypeError>
+    {
+        // Evaluations are not permitted to contain error types.
+        if (node.expression.error != null)
+            return TypeError.EvaluateHasError(node.expression).toFailure()
+        
+        // Evaluations are not permitted to contain value types.
+        if (node.expression.value != null)
+            return TypeError.EvaluateHasValue(node.expression).toFailure()
+        
+        // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
+        return Unit.toSuccess()
+    }
     
-    // Evaluations are not permitted to contain value types.
-    if (node.expression.value != null)
-        return TypeError.EvaluateHasValue(node.expression).toFailure()
+    private fun handle(node: ThirReturn): Result<Unit, TypeError>
+    {
+        // If the context requires an error to be raised, we cannot simply bail from the callable.
+        if (error != null)
+            return TypeError.ReturnLacksError.toFailure()
+        
+        // If the context requires a value to be returned, we cannot simply bail from the callable.
+        if (value != null)
+            return TypeError.ReturnLacksValue.toFailure()
+        
+        return Unit.toSuccess()
+    }
     
-    return Unit.toSuccess()
+    private fun handle(node: ThirReturnValue): Result<Unit, TypeError>
+    {
+        // If the function is not permitted to return anything, we cannot return anything.
+        if (value == null)
+            return TypeError.ReturnHasValue(node.value).toFailure()
+        
+        // If the expected value type is different, we have incompatible types.
+        // TODO: Support generics.
+        // TODO: Support mutable types.
+        // TODO: Support union types.
+        if (value != node.value.value)
+            return TypeError.ReturnWrongValue(node.value).toFailure()
+        
+        // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
+        return Unit.toSuccess()
+    }
+    
+    private fun handle(node: ThirReturnError): Result<Unit, TypeError>
+    {
+        // If the function is not permitted to raise anything, we cannot raise anything.
+        if (error == null)
+            return TypeError.ReturnHasError(node.error).toFailure()
+        
+        // If the expected error type is different, we have incompatible types.
+        // TODO: Support generics.
+        // TODO: Support mutable types.
+        // TODO: Support union types.
+        if (error != node.error.error)
+            return TypeError.ReturnWrongError(node.error).toFailure()
+        
+        // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
+        return Unit.toSuccess()
+    }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -27,12 +27,12 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
     {
         // Predicates are not permitted to contain error types.
         if (node.predicate.error != null)
-            return TypeError.BranchPredicateHasError(node.predicate).toFailure()
+            return TypeError.BranchHasError(node.predicate).toFailure()
         
         // The value type must be boolean.
         val value = node.predicate.value as? ThirTypeData
         if (value == null || value.symbolId != Builtin.BOOL.id)
-            return TypeError.BranchPredicateNotBool(node.predicate).toFailure()
+            return TypeError.BranchWrongValue(node.predicate).toFailure()
         
         // TODO: Type-check the predicate too, ensure that it does not contain any forbidden values either.
         return Unit.toSuccess()
@@ -69,14 +69,14 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
     {
         // If the function is not permitted to return anything, we cannot return anything.
         if (value == null)
-            return TypeError.ReturnHasValue(node.value).toFailure()
+            return TypeError.ReturnHasValue(node.expression).toFailure()
         
         // If the expected value type is different, we have incompatible types.
         // TODO: Support generics.
         // TODO: Support mutable types.
         // TODO: Support union types.
-        if (value != node.value.value)
-            return TypeError.ReturnWrongValue(node.value).toFailure()
+        if (value != node.expression.value)
+            return TypeError.ReturnWrongValue(node.expression).toFailure()
         
         // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
         return Unit.toSuccess()
@@ -86,14 +86,14 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
     {
         // If the function is not permitted to raise anything, we cannot raise anything.
         if (error == null)
-            return TypeError.ReturnHasError(node.error).toFailure()
+            return TypeError.ReturnHasError(node.expression).toFailure()
         
         // If the expected error type is different, we have incompatible types.
         // TODO: Support generics.
         // TODO: Support mutable types.
         // TODO: Support union types.
-        if (error != node.error.error)
-            return TypeError.ReturnWrongError(node.error).toFailure()
+        if (error != node.expression.error)
+            return TypeError.ReturnWrongError(node.expression).toFailure()
         
         // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
         return Unit.toSuccess()

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
@@ -34,12 +34,12 @@ data object HirReturn : HirInstruction
 
 /**
  * Exits the current function call, returning control flow to whoever called the function in the first place. The
- * error value of the function is provided by the given [value].
+ * error value of the function is provided by the given [expression].
  */
-data class HirReturnError(val value: HirValue) : HirInstruction
+data class HirReturnError(val expression: HirValue) : HirInstruction
 
 /**
  * Exits the current function call, returning control flow to whoever called the function in the first place. The
- * return value of the function is provided by the given [value].
+ * return value of the function is provided by the given [expression].
  */
-data class HirReturnValue(val value: HirValue) : HirInstruction
+data class HirReturnValue(val expression: HirValue) : HirInstruction

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
@@ -36,12 +36,12 @@ data object ThirReturn : ThirInstruction
 
 /**
  * Exits the current function call, returning control flow to whoever called the function in the first place. The
- * error value of the function is provided by the given [error].
+ * error value of the function is provided by the given [expression].
  */
-data class ThirReturnError(val error: ThirValue) : ThirInstruction
+data class ThirReturnError(val expression: ThirValue) : ThirInstruction
 
 /**
  * Exits the current function call, returning control flow to whoever called the function in the first place. The
- * return value of the function is provided by the given [value].
+ * return value of the function is provided by the given [expression].
  */
-data class ThirReturnValue(val value: ThirValue) : ThirInstruction
+data class ThirReturnValue(val expression: ThirValue) : ThirInstruction

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -24,7 +24,7 @@ class TestCheckerInstructions
         fun `Given invalid value type, when checking, then correct error`()
         {
             val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
-            val expected = TypeError.BranchPredicateNotBool(input)
+            val expected = TypeError.BranchWrongValue(input)
             
             assertFailure(expected, checker.check(input.thirBranch()))
         }
@@ -33,7 +33,7 @@ class TestCheckerInstructions
         fun `Given invalid error type, when checking, then correct error`()
         {
             val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = thirTypeData()).thirCall()
-            val expected = TypeError.BranchPredicateHasError(input)
+            val expected = TypeError.BranchHasError(input)
             
             assertFailure(expected, checker.check(input.thirBranch()))
         }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -10,12 +10,14 @@ class TestCheckerInstructions
     @Nested
     inner class Branch
     {
+        private val checker = CheckerInstruction(value = null, error = null)
+        
         @Test
         fun `Given valid type, when checking, then correct outcome`()
         {
             val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = null).thirCall()
             
-            assertSuccess(Unit, check(input.thirBranch()))
+            assertSuccess(Unit, checker.check(input.thirBranch()))
         }
         
         @Test
@@ -24,7 +26,7 @@ class TestCheckerInstructions
             val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
             val expected = TypeError.BranchPredicateNotBool(input)
             
-            assertFailure(expected, check(input.thirBranch()))
+            assertFailure(expected, checker.check(input.thirBranch()))
         }
         
         @Test
@@ -33,19 +35,21 @@ class TestCheckerInstructions
             val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = thirTypeData()).thirCall()
             val expected = TypeError.BranchPredicateHasError(input)
             
-            assertFailure(expected, check(input.thirBranch()))
+            assertFailure(expected, checker.check(input.thirBranch()))
         }
     }
     
     @Nested
     inner class Evaluate
     {
+        private val checker = CheckerInstruction(value = null, error = null)
+        
         @Test
         fun `Given valid type, when checking, then correct outcome`()
         {
             val input = thirFunOf(value = null, error = null).thirCall()
             
-            assertSuccess(Unit, check(input.thirEval))
+            assertSuccess(Unit, checker.check(input.thirEval))
         }
         
         @Test
@@ -54,7 +58,7 @@ class TestCheckerInstructions
             val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
             val expected = TypeError.EvaluateHasValue(input)
             
-            assertFailure(expected, check(input.thirEval))
+            assertFailure(expected, checker.check(input.thirEval))
         }
         
         @Test
@@ -63,7 +67,95 @@ class TestCheckerInstructions
             val input = thirFunOf(value = null, error = thirTypeData()).thirCall()
             val expected = TypeError.EvaluateHasError(input)
             
-            assertFailure(expected, check(input.thirEval))
+            assertFailure(expected, checker.check(input.thirEval))
+        }
+    }
+    
+    @Nested
+    inner class Return
+    {
+        private val checkerEmpty = CheckerInstruction(value = null, error = null)
+        private val checkerValue = CheckerInstruction(value = thirTypeData(Builtin.BOOL.id), error = null)
+        private val checkerError = CheckerInstruction(value = null, error = thirTypeData(Builtin.BOOL.id))
+        
+        @Test
+        fun `Given no types, when checking, then correct outcome`()
+        {
+            assertSuccess(Unit, checkerEmpty.check(ThirReturn))
+        }
+        
+        @Test
+        fun `Given value type, when checking, then correct error`()
+        {
+            assertFailure(TypeError.ReturnLacksValue, checkerValue.check(ThirReturn))
+        }
+        
+        @Test
+        fun `Given error type, when checking, then correct error`()
+        {
+            assertFailure(TypeError.ReturnLacksError, checkerError.check(ThirReturn))
+        }
+    }
+    
+    @Nested
+    inner class ReturnValue
+    {
+        private val checkerEmpty = CheckerInstruction(value = null, error = null)
+        private val checkerValue = CheckerInstruction(value = thirTypeData(Builtin.BOOL.id), error = null)
+        
+        @Test
+        fun `Given valid type, when checking, then correct outcome`()
+        {
+            val value = thirFunOf(value = thirTypeData(Builtin.BOOL.id)).thirCall()
+            
+            assertSuccess(Unit, checkerValue.check(value.thirReturnValue))
+        }
+        
+        @Test
+        fun `Given no type, when checking, then correct error`()
+        {
+            val value = thirFunOf(value = null).thirCall()
+            
+            assertFailure(TypeError.ReturnHasValue(value), checkerEmpty.check(value.thirReturnValue))
+        }
+        
+        @Test
+        fun `Given invalid type, when checking, then correct error`()
+        {
+            val value = thirFunOf(value = thirTypeData(Builtin.INT32.id)).thirCall()
+            
+            assertFailure(TypeError.ReturnWrongValue(value), checkerValue.check(value.thirReturnValue))
+        }
+    }
+    
+    @Nested
+    inner class ReturnError
+    {
+        private val checkerEmpty = CheckerInstruction(value = null, error = null)
+        private val checkerError = CheckerInstruction(value = null, error = thirTypeData(Builtin.BOOL.id))
+        
+        @Test
+        fun `Given valid type, when checking, then correct outcome`()
+        {
+            val error = thirFunOf(error = thirTypeData(Builtin.BOOL.id)).thirCall()
+            
+            assertSuccess(Unit, checkerError.check(error.thirReturnError))
+        }
+        
+        @Test
+        fun `Given no type, when checking, then correct error`()
+        {
+            val error = thirFunOf(error = null).thirCall()
+            
+            assertFailure(TypeError.ReturnHasError(error), checkerEmpty.check(error.thirReturnError))
+        }
+        
+        @Test
+        fun `Given invalid type, when checking, then correct error`()
+        {
+            val error = thirFunOf(error = thirTypeData(Builtin.INT32.id)).thirCall()
+            
+            assertFailure(TypeError.ReturnWrongError(error), checkerError.check(error.thirReturnError))
         }
     }
 }


### PR DESCRIPTION
In this pull request, we introduce support for type-checking return statements of all forms. We are not yet supporting the catch expressions yet, but those will be handled in a different pull request. Here, we start shaping up the code to handle a context; almost all instructions will be inside some form of callable context, which typically expects some form of return value or error.