### PR TITLE
135 implement type-checker ensuring return statements have no errors

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -9,6 +9,11 @@ import com.github.derg.transpiler.source.thir.*
 sealed interface TypeError
 {
     /**
+     * The branch [predicate] evaluates to no type at all.
+     */
+    data class BranchMissingValue(val predicate: ThirValue) : TypeError
+    
+    /**
      * The branch [predicate] did not evaluate to a boolean type, which is required by the branch predicate.
      */
     data class BranchWrongValue(val predicate: ThirValue) : TypeError

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -16,45 +16,40 @@ sealed interface TypeError
     /**
      * The branch [predicate] is evaluated to a possible error type, which is not permitted.
      */
-    data class BranchHasError(val predicate: ThirValue) : TypeError
+    data class BranchContainsError(val predicate: ThirValue) : TypeError
     
     /**
      * The provided [expression] is evaluated to a possible value, which is not permitted.
      */
-    data class EvaluateHasValue(val expression: ThirValue) : TypeError
+    data class EvaluateContainsValue(val expression: ThirValue) : TypeError
     
     /**
      * The provided [expression] is evaluated to a possible error, which is not permitted.
      */
-    data class EvaluateHasError(val expression: ThirValue) : TypeError
+    data class EvaluateContainsError(val expression: ThirValue) : TypeError
     
     /**
      * The return statement lacks a value associated with it, when the callable expected something to be returned.
      */
-    data object ReturnLacksValue : TypeError
+    data object ReturnMissingExpression : TypeError
     
     /**
-     * The return statement lacks an error associated with it, when the callable expected something to be raised.
+     * The return statement has an [expression] which evaluates to no type at all.
      */
-    data object ReturnLacksError : TypeError
+    data class ReturnMissingValue(val expression: ThirValue) : TypeError
     
     /**
-     * The return statement has a [expression] which evaluates to a value, when no return value was expected.
+     * The return statement has an [expression] which evaluates to the wrong type.
      */
-    data class ReturnHasValue(val expression: ThirValue) : TypeError
+    data class ReturnWrongType(val expression: ThirValue) : TypeError
+    
+    /**
+     * The return statement has an [expression] which evaluates to a value, when no return value was expected.
+     */
+    data class ReturnContainsValue(val expression: ThirValue) : TypeError
     
     /**
      * The return statement has an [expression] which evaluates to an error, when no return error was expected.
      */
-    data class ReturnHasError(val expression: ThirValue) : TypeError
-    
-    /**
-     * The return statement has an [expression] which evaluates to the wrong value type.
-     */
-    data class ReturnWrongValue(val expression: ThirValue) : TypeError
-    
-    /**
-     * The return statement has an [expression] which evaluates to the wrong error type.
-     */
-    data class ReturnWrongError(val expression: ThirValue) : TypeError
+    data class ReturnContainsError(val expression: ThirValue) : TypeError
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -30,8 +30,8 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
             return TypeError.BranchContainsError(node.predicate).toFailure()
         
         // The value type must be boolean.
-        val value = node.predicate.value as? ThirTypeData
-        if (value == null || value.symbolId != Builtin.BOOL.id)
+        val value = node.predicate.value ?: return TypeError.BranchMissingValue(node.predicate).toFailure()
+        if (value !is ThirTypeData || value.symbolId != Builtin.BOOL.id)
             return TypeError.BranchWrongValue(node.predicate).toFailure()
         
         // TODO: Type-check the predicate too, ensure that it does not contain any forbidden values either.
@@ -93,7 +93,7 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         // If the function is not permitted to raise anything, we cannot raise anything.
         if (error == null)
             return TypeError.ReturnContainsValue(node.expression).toFailure()
-    
+        
         // The expression must evaluate to exactly a value type, no error type is permitted.
         if (node.expression.value == null)
             return TypeError.ReturnMissingValue(node.expression).toFailure()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -18,7 +18,7 @@ class TestCheckerInstructions
         @Test
         fun `Given valid type, when checking, then correct outcome`()
         {
-            val input = thirFunOf(value = bool, error = null).thirCall()
+            val input = thirFunOf(value = bool).thirCall()
             
             assertSuccess(Unit, checker.check(input.thirBranch()))
         }
@@ -26,19 +26,27 @@ class TestCheckerInstructions
         @Test
         fun `Given invalid value type, when checking, then correct error`()
         {
-            val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
+            val input = thirFunOf(value = thirTypeData()).thirCall()
             val expected = TypeError.BranchWrongValue(input)
             
             assertFailure(expected, checker.check(input.thirBranch()))
         }
         
         @Test
-        fun `Given invalid error type, when checking, then correct error`()
+        fun `Given error type, when checking, then correct error`()
         {
-            val input = thirFunOf(value = bool, error = thirTypeData()).thirCall()
+            val input = thirFunOf(value = bool, error = bool).thirCall()
             val expected = TypeError.BranchContainsError(input)
             
             assertFailure(expected, checker.check(input.thirBranch()))
+        }
+        
+        @Test
+        fun `Given no type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = null).thirCall()
+            
+            assertFailure(TypeError.BranchMissingValue(input), checker.check(input.thirBranch()))
         }
     }
     
@@ -108,14 +116,6 @@ class TestCheckerInstructions
         }
         
         @Test
-        fun `Given no type, when checking, then correct error`()
-        {
-            val input = thirFunOf(value = null).thirCall()
-            
-            assertFailure(TypeError.ReturnMissingValue(input), checkerValue.check(input.thirReturnValue))
-        }
-        
-        @Test
         fun `Given invalid type, when checking, then correct error`()
         {
             val input = thirFunOf(value = int32).thirCall()
@@ -132,9 +132,17 @@ class TestCheckerInstructions
         }
         
         @Test
-        fun `Given bad return, when checking, then correct error`()
+        fun `Given no type, when checking, then correct error`()
         {
-            val input = thirFunOf(value = int32).thirCall()
+            val input = thirFunOf(value = null).thirCall()
+            
+            assertFailure(TypeError.ReturnMissingValue(input), checkerValue.check(input.thirReturnValue))
+        }
+        
+        @Test
+        fun `Given forbidden return, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = bool).thirCall()
             
             assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnValue))
         }
@@ -155,14 +163,6 @@ class TestCheckerInstructions
         }
         
         @Test
-        fun `Given no type, when checking, then correct error`()
-        {
-            val input = thirFunOf(value = null).thirCall()
-            
-            assertFailure(TypeError.ReturnMissingValue(input), checkerError.check(input.thirReturnError))
-        }
-        
-        @Test
         fun `Given invalid type, when checking, then correct error`()
         {
             val input = thirFunOf(value = int32).thirCall()
@@ -179,9 +179,17 @@ class TestCheckerInstructions
         }
         
         @Test
-        fun `Given bad return, when checking, then correct error`()
+        fun `Given no type, when checking, then correct error`()
         {
-            val input = thirFunOf(value = int32).thirCall()
+            val input = thirFunOf(value = null).thirCall()
+            
+            assertFailure(TypeError.ReturnMissingValue(input), checkerError.check(input.thirReturnError))
+        }
+        
+        @Test
+        fun `Given forbidden return, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = bool).thirCall()
             
             assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnError))
         }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.*
 
 class TestCheckerInstructions
 {
+    private val bool = thirTypeData(Builtin.BOOL.id)
+    private val int32 = thirTypeData(Builtin.INT32.id)
+    
     @Nested
     inner class Branch
     {
@@ -15,7 +18,7 @@ class TestCheckerInstructions
         @Test
         fun `Given valid type, when checking, then correct outcome`()
         {
-            val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = null).thirCall()
+            val input = thirFunOf(value = bool, error = null).thirCall()
             
             assertSuccess(Unit, checker.check(input.thirBranch()))
         }
@@ -32,8 +35,8 @@ class TestCheckerInstructions
         @Test
         fun `Given invalid error type, when checking, then correct error`()
         {
-            val input = thirFunOf(value = thirTypeData(Builtin.BOOL.id), error = thirTypeData()).thirCall()
-            val expected = TypeError.BranchHasError(input)
+            val input = thirFunOf(value = bool, error = thirTypeData()).thirCall()
+            val expected = TypeError.BranchContainsError(input)
             
             assertFailure(expected, checker.check(input.thirBranch()))
         }
@@ -56,7 +59,7 @@ class TestCheckerInstructions
         fun `Given invalid value type, when checking, then correct error`()
         {
             val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
-            val expected = TypeError.EvaluateHasValue(input)
+            val expected = TypeError.EvaluateContainsValue(input)
             
             assertFailure(expected, checker.check(input.thirEval))
         }
@@ -65,7 +68,7 @@ class TestCheckerInstructions
         fun `Given invalid error type, when checking, then correct error`()
         {
             val input = thirFunOf(value = null, error = thirTypeData()).thirCall()
-            val expected = TypeError.EvaluateHasError(input)
+            val expected = TypeError.EvaluateContainsError(input)
             
             assertFailure(expected, checker.check(input.thirEval))
         }
@@ -75,8 +78,7 @@ class TestCheckerInstructions
     inner class Return
     {
         private val checkerEmpty = CheckerInstruction(value = null, error = null)
-        private val checkerValue = CheckerInstruction(value = thirTypeData(Builtin.BOOL.id), error = null)
-        private val checkerError = CheckerInstruction(value = null, error = thirTypeData(Builtin.BOOL.id))
+        private val checkerValue = CheckerInstruction(value = bool, error = null)
         
         @Test
         fun `Given no types, when checking, then correct outcome`()
@@ -87,13 +89,7 @@ class TestCheckerInstructions
         @Test
         fun `Given value type, when checking, then correct error`()
         {
-            assertFailure(TypeError.ReturnLacksValue, checkerValue.check(ThirReturn))
-        }
-        
-        @Test
-        fun `Given error type, when checking, then correct error`()
-        {
-            assertFailure(TypeError.ReturnLacksError, checkerError.check(ThirReturn))
+            assertFailure(TypeError.ReturnMissingExpression, checkerValue.check(ThirReturn))
         }
     }
     
@@ -101,30 +97,46 @@ class TestCheckerInstructions
     inner class ReturnValue
     {
         private val checkerEmpty = CheckerInstruction(value = null, error = null)
-        private val checkerValue = CheckerInstruction(value = thirTypeData(Builtin.BOOL.id), error = null)
+        private val checkerValue = CheckerInstruction(value = bool, error = null)
         
         @Test
         fun `Given valid type, when checking, then correct outcome`()
         {
-            val value = thirFunOf(value = thirTypeData(Builtin.BOOL.id)).thirCall()
+            val input = thirFunOf(value = bool).thirCall()
             
-            assertSuccess(Unit, checkerValue.check(value.thirReturnValue))
+            assertSuccess(Unit, checkerValue.check(input.thirReturnValue))
         }
         
         @Test
         fun `Given no type, when checking, then correct error`()
         {
-            val value = thirFunOf(value = null).thirCall()
+            val input = thirFunOf(value = null).thirCall()
             
-            assertFailure(TypeError.ReturnHasValue(value), checkerEmpty.check(value.thirReturnValue))
+            assertFailure(TypeError.ReturnMissingValue(input), checkerValue.check(input.thirReturnValue))
         }
         
         @Test
         fun `Given invalid type, when checking, then correct error`()
         {
-            val value = thirFunOf(value = thirTypeData(Builtin.INT32.id)).thirCall()
+            val input = thirFunOf(value = int32).thirCall()
             
-            assertFailure(TypeError.ReturnWrongValue(value), checkerValue.check(value.thirReturnValue))
+            assertFailure(TypeError.ReturnWrongType(input), checkerValue.check(input.thirReturnValue))
+        }
+        
+        @Test
+        fun `Given error type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = bool, error = bool).thirCall()
+            
+            assertFailure(TypeError.ReturnContainsError(input), checkerValue.check(input.thirReturnValue))
+        }
+        
+        @Test
+        fun `Given bad return, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = int32).thirCall()
+            
+            assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnValue))
         }
     }
     
@@ -132,30 +144,46 @@ class TestCheckerInstructions
     inner class ReturnError
     {
         private val checkerEmpty = CheckerInstruction(value = null, error = null)
-        private val checkerError = CheckerInstruction(value = null, error = thirTypeData(Builtin.BOOL.id))
+        private val checkerError = CheckerInstruction(value = null, error = bool)
         
         @Test
         fun `Given valid type, when checking, then correct outcome`()
         {
-            val error = thirFunOf(error = thirTypeData(Builtin.BOOL.id)).thirCall()
+            val input = thirFunOf(value = bool).thirCall()
             
-            assertSuccess(Unit, checkerError.check(error.thirReturnError))
+            assertSuccess(Unit, checkerError.check(input.thirReturnError))
         }
         
         @Test
         fun `Given no type, when checking, then correct error`()
         {
-            val error = thirFunOf(error = null).thirCall()
+            val input = thirFunOf(value = null).thirCall()
             
-            assertFailure(TypeError.ReturnHasError(error), checkerEmpty.check(error.thirReturnError))
+            assertFailure(TypeError.ReturnMissingValue(input), checkerError.check(input.thirReturnError))
         }
         
         @Test
         fun `Given invalid type, when checking, then correct error`()
         {
-            val error = thirFunOf(error = thirTypeData(Builtin.INT32.id)).thirCall()
+            val input = thirFunOf(value = int32).thirCall()
             
-            assertFailure(TypeError.ReturnWrongError(error), checkerError.check(error.thirReturnError))
+            assertFailure(TypeError.ReturnWrongType(input), checkerError.check(input.thirReturnError))
+        }
+        
+        @Test
+        fun `Given error type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = bool, error = bool).thirCall()
+            
+            assertFailure(TypeError.ReturnContainsError(input), checkerError.check(input.thirReturnError))
+        }
+        
+        @Test
+        fun `Given bad return, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = int32).thirCall()
+            
+            assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnError))
         }
     }
 }


### PR DESCRIPTION
This pull request fixes the type-checking of return statements, such that the error cases are properly handled. Here, errors which occur in the return statements are properly rejected, ensuring that the developer must handle errors rather than ignore them.