### PR TITLE
140 implement type checker for variable assignment

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
@@ -42,10 +42,10 @@ internal class ResolverInstruction(private val types: TypeTable, private val sco
         {
             1    -> candidates.single()
             0    -> return ResolveError.UnknownVariable(node.instance.name).toFailure()
-            else -> return ResolveError.AmbiguousVariable(node.instance.name, node.value).toFailure()
+            else -> return ResolveError.AmbiguousVariable(node.instance.name, node.expression).toFailure()
         }
         
-        val value = values.resolve(node.value).valueOr { return it.toFailure() }
+        val value = values.resolve(node.expression).valueOr { return it.toFailure() }
         return ThirAssign(candidate.id, value).toSuccess()
     }
     

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -9,6 +9,21 @@ import com.github.derg.transpiler.source.thir.*
 sealed interface TypeError
 {
     /**
+     * The assignment [expression] evaluates to no type at all.
+     */
+    data class AssignMissingValue(val expression: ThirValue) : TypeError
+    
+    /**
+     * The assignment [expression] did not evaluate to a type compatible with the variable.
+     */
+    data class AssignWrongType(val expression: ThirValue) : TypeError
+    
+    /**
+     * The assignment [expression] is evaluated to a possible error type, which is not permitted.
+     */
+    data class AssignContainsError(val expression: ThirValue) : TypeError
+    
+    /**
      * The branch [predicate] evaluates to no type at all.
      */
     data class BranchMissingValue(val predicate: ThirValue) : TypeError
@@ -16,7 +31,7 @@ sealed interface TypeError
     /**
      * The branch [predicate] did not evaluate to a boolean type, which is required by the branch predicate.
      */
-    data class BranchWrongValue(val predicate: ThirValue) : TypeError
+    data class BranchWrongType(val predicate: ThirValue) : TypeError
     
     /**
      * The branch [predicate] is evaluated to a possible error type, which is not permitted.

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
@@ -7,9 +7,9 @@ package com.github.derg.transpiler.source.hir
 sealed interface HirInstruction
 
 /**
- * Assigns the specified [value] to the object located under the given [instance].
+ * Assigns the specified [expression] to the object located under the given [instance].
  */
-data class HirAssign(val instance: HirValue, val value: HirValue) : HirInstruction
+data class HirAssign(val instance: HirValue, val expression: HirValue) : HirInstruction
 
 /**
  * Conditional execution is possible by branching the control flow one a [predicate]. If the predicates matches, the

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
@@ -9,9 +9,9 @@ import java.util.*
 sealed interface ThirInstruction
 
 /**
- * Assigns the specified [value] to the [symbolId].
+ * Assigns the specified [expression] to the [symbolId].
  */
-data class ThirAssign(val symbolId: UUID, val value: ThirValue) : ThirInstruction
+data class ThirAssign(val symbolId: UUID, val expression: ThirValue) : ThirInstruction
 
 /**
  * Conditional execution is possible by branching the control flow one a [predicate]. If the predicates matches, the

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -11,6 +11,45 @@ class TestCheckerInstructions
     private val int32 = thirTypeData(Builtin.INT32.id)
     
     @Nested
+    inner class Assign
+    {
+        private val checker = CheckerInstruction(value = bool, error = null)
+        private val variable = thirVarOf(type = bool)
+        
+        @Test
+        fun `Given valid type, when checking, then correct outcome`()
+        {
+            val input = thirFunOf(value = bool).thirCall()
+            
+            assertSuccess(Unit, checker.check(variable.thirAssign(input)))
+        }
+        
+        @Test
+        fun `Given invalid type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = thirTypeData()).thirCall()
+            
+            assertFailure(TypeError.AssignWrongType(input), checker.check(variable.thirAssign(input)))
+        }
+        
+        @Test
+        fun `Given error type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = bool, error = bool).thirCall()
+            
+            assertFailure(TypeError.AssignContainsError(input), checker.check(variable.thirAssign(input)))
+        }
+        
+        @Test
+        fun `Given no type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = null).thirCall()
+            
+            assertFailure(TypeError.AssignMissingValue(input), checker.check(variable.thirAssign(input)))
+        }
+    }
+    
+    @Nested
     inner class Branch
     {
         private val checker = CheckerInstruction(value = null, error = null)
@@ -24,21 +63,19 @@ class TestCheckerInstructions
         }
         
         @Test
-        fun `Given invalid value type, when checking, then correct error`()
+        fun `Given invalid type, when checking, then correct error`()
         {
             val input = thirFunOf(value = thirTypeData()).thirCall()
-            val expected = TypeError.BranchWrongValue(input)
             
-            assertFailure(expected, checker.check(input.thirBranch()))
+            assertFailure(TypeError.BranchWrongType(input), checker.check(input.thirBranch()))
         }
         
         @Test
         fun `Given error type, when checking, then correct error`()
         {
             val input = thirFunOf(value = bool, error = bool).thirCall()
-            val expected = TypeError.BranchContainsError(input)
             
-            assertFailure(expected, checker.check(input.thirBranch()))
+            assertFailure(TypeError.BranchContainsError(input), checker.check(input.thirBranch()))
         }
         
         @Test
@@ -56,7 +93,7 @@ class TestCheckerInstructions
         private val checker = CheckerInstruction(value = null, error = null)
         
         @Test
-        fun `Given valid type, when checking, then correct outcome`()
+        fun `Given no type, when checking, then correct outcome`()
         {
             val input = thirFunOf(value = null, error = null).thirCall()
             
@@ -64,21 +101,19 @@ class TestCheckerInstructions
         }
         
         @Test
-        fun `Given invalid value type, when checking, then correct error`()
+        fun `Given value type, when checking, then correct error`()
         {
             val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
-            val expected = TypeError.EvaluateContainsValue(input)
             
-            assertFailure(expected, checker.check(input.thirEval))
+            assertFailure(TypeError.EvaluateContainsValue(input), checker.check(input.thirEval))
         }
         
         @Test
-        fun `Given invalid error type, when checking, then correct error`()
+        fun `Given error type, when checking, then correct error`()
         {
             val input = thirFunOf(value = null, error = thirTypeData()).thirCall()
-            val expected = TypeError.EvaluateContainsError(input)
             
-            assertFailure(expected, checker.check(input.thirEval))
+            assertFailure(TypeError.EvaluateContainsError(input), checker.check(input.thirEval))
         }
     }
     
@@ -89,7 +124,7 @@ class TestCheckerInstructions
         private val checkerValue = CheckerInstruction(value = bool, error = null)
         
         @Test
-        fun `Given no types, when checking, then correct outcome`()
+        fun `Given no type, when checking, then correct outcome`()
         {
             assertSuccess(Unit, checkerEmpty.check(ThirReturn))
         }


### PR DESCRIPTION
In this pull request, we introduce the basic type-checking for variable assignments. This is a far cry from a complete and good solution, but it gets the ball rolling. With this change, we can perform rudimentary matching on the type of the variable with the type of the expression. We reject all programs where the types are misaligned.