### PR TITLE
Introduce initial prototype type-checker phase

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/Main.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/Main.kt
@@ -1,3 +1,30 @@
 package com.github.derg.transpiler
 
-fun main(args: Array<String>) = Unit
+import com.github.derg.transpiler.phases.converter.*
+import com.github.derg.transpiler.phases.parser.*
+import com.github.derg.transpiler.phases.resolver.*
+import com.github.derg.transpiler.phases.typechecker.*
+import com.github.derg.transpiler.utils.*
+
+private const val SOURCE = """
+    fun foo() -> __builtin_i32
+    {
+        return bar(2) * 4
+    }
+    
+    fun bar(a: __builtin_i32) -> __builtin_i32
+    {
+        return 3i32
+    }
+"""
+
+fun main(args: Array<String>)
+{
+    val ast = parse(SOURCE).valueOrDie()
+    val hir = convert(listOf(ast))
+    val thir = resolve(hir).valueOrDie()
+    
+    check(thir).valueOrDie()
+    
+    println("Functions: \n\t" + thir.functions.values.joinToString("\n\t") { it.toString() })
+}

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
@@ -57,9 +57,9 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
     
     private fun handle(node: HirFunction): Result<ThirSymbol, ResolveError>
     {
-//        node.generics.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
-//        node.variables.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
-        node.parameters.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
+//        node.generics.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
+//        node.variables.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
+        node.parameters.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
         
         val symbol = ThirFunction(
             id = node.id,
@@ -78,8 +78,8 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
     
     private fun handle(node: HirLiteral): Result<ThirSymbol, ResolveError>
     {
-//        node.variables.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
-        resolve(node.parameter).onFailure { return it.toFailure() }
+//        node.variables.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
+        handle(node.parameter).onFailure { return it.toFailure() }
         
         val symbol = ThirLiteral(
             id = node.id,
@@ -111,9 +111,9 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
     
     private fun handle(node: HirStruct): Result<ThirSymbol, ResolveError>
     {
-        node.fields.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
-//        node.methods.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
-//        node.generics.mapUntilError { resolve(it) }.onFailure { return it.toFailure() }
+        node.fields.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
+//        node.methods.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
+//        node.generics.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
         
         val symbol = ThirStruct(
             id = node.id,

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -1,6 +1,24 @@
 package com.github.derg.transpiler.phases.typechecker
 
+import com.github.derg.transpiler.phases.resolver.*
 import com.github.derg.transpiler.source.thir.*
+import com.github.derg.transpiler.utils.*
+
+/**
+ * Performs type-checking across all entries in the symbol [table].
+ */
+// TODO: Super-superficial type-checker operating on a whole symbol table.
+fun check(table: SymbolTable): Result<Unit, TypeError>
+{
+    for (function in table.functions.values)
+    {
+        val checker = CheckerInstruction(function.type.value, function.type.error)
+        
+        function.instructions.mapUntilError { checker.check(it) }.valueOr { return it.toFailure() }
+    }
+    
+    return Unit.toSuccess()
+}
 
 /**
  * During the type checking phase, a variety of type errors may arise. These errors describe why a type cannot be used


### PR DESCRIPTION
Here, we introduce the basic of the type-checker phase. This stage works by iterating through all symbols defined within the symbol table, ensuring that the types of every statement makes sense, and that values provided to variables, parameters, etc. all match up. Once the compilation has passed this step, the program being compiled should be type-safe.