### PR TITLE
Fix issue where return statements could not be used

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -72,10 +72,6 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
     
     private fun handle(node: ThirReturn): Result<Unit, TypeError>
     {
-        // If the context requires an error to be raised, we cannot simply bail from the callable.
-        if (error != null)
-            return TypeError.ReturnMissingExpression.toFailure()
-        
         // If the context requires a value to be returned, we cannot simply bail from the callable.
         if (value != null)
             return TypeError.ReturnMissingExpression.toFailure()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -122,11 +122,18 @@ class TestCheckerInstructions
     {
         private val checkerEmpty = CheckerInstruction(value = null, error = null)
         private val checkerValue = CheckerInstruction(value = bool, error = null)
+        private val checkerError = CheckerInstruction(value = null, error = bool)
         
         @Test
         fun `Given no type, when checking, then correct outcome`()
         {
             assertSuccess(Unit, checkerEmpty.check(ThirReturn))
+        }
+        
+        @Test
+        fun `Given error type, when checking, then correct outcome`()
+        {
+            assertSuccess(Unit, checkerError.check(ThirReturn))
         }
         
         @Test


### PR DESCRIPTION
This pull request fixes the issue where it would not be possible to early return from a function allowing errors to be raised.