### PR TITLE
Add type-checker for call expressions

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -57,6 +57,21 @@ sealed interface TypeError
     data class BranchContainsError(val predicate: ThirValue) : TypeError
     
     /**
+     * The call [instance] does not evaluate to something which has any value type.
+     */
+    data class CallMissingValue(val instance: ThirValue) : TypeError
+    
+    /**
+     * The call [instance] did not evaluate to a type which is callable.
+     */
+    data class CallWrongType(val instance: ThirValue) : TypeError
+    
+    /**
+     * The call [instance] is evaluated to a possible error type, which is not permitted.
+     */
+    data class CallContainsError(val instance: ThirValue) : TypeError
+    
+    /**
      * The provided [expression] is evaluated to a possible value, which is not permitted.
      */
     data class EvaluateContainsValue(val expression: ThirValue) : TypeError

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -38,7 +38,7 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         if (value != node.expression.value)
             return TypeError.AssignWrongType(node.expression).toFailure()
         
-        return Unit.toSuccess()
+        return CheckerValue().check(node.expression)
     }
     
     private fun handle(node: ThirBranch): Result<Unit, TypeError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -95,9 +95,8 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         // TODO: Support union types.
         if (value != node.expression.value)
             return TypeError.ReturnWrongType(node.expression).toFailure()
-        
-        // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
-        return Unit.toSuccess()
+    
+        return CheckerValue().check(node.expression)
     }
     
     private fun handle(node: ThirReturnError): Result<Unit, TypeError>
@@ -118,8 +117,7 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         // TODO: Support union types.
         if (error != node.expression.value)
             return TypeError.ReturnWrongType(node.expression).toFailure()
-        
-        // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
-        return Unit.toSuccess()
+    
+        return CheckerValue().check(node.expression)
     }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -37,7 +37,7 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         // TODO: Support union types.
         if (value != node.expression.value)
             return TypeError.AssignWrongType(node.expression).toFailure()
-        
+    
         return CheckerValue().check(node.expression)
     }
     
@@ -51,9 +51,8 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         val value = node.predicate.value ?: return TypeError.BranchMissingValue(node.predicate).toFailure()
         if (value !is ThirTypeData || value.symbolId != Builtin.BOOL.id)
             return TypeError.BranchWrongType(node.predicate).toFailure()
-        
-        // TODO: Type-check the predicate too, ensure that it does not contain any forbidden values either.
-        return Unit.toSuccess()
+    
+        return CheckerValue().check(node.predicate)
     }
     
     private fun handle(node: ThirEvaluate): Result<Unit, TypeError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -64,9 +64,8 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         // Evaluations are not permitted to contain value types.
         if (node.expression.value != null)
             return TypeError.EvaluateContainsValue(node.expression).toFailure()
-        
-        // TODO: Type-check the expression too, ensure that it does not contain any forbidden values either.
-        return Unit.toSuccess()
+    
+        return CheckerValue().check(node.expression)
     }
     
     private fun handle(node: ThirReturn): Result<Unit, TypeError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -1,0 +1,39 @@
+package com.github.derg.transpiler.phases.typechecker
+
+import com.github.derg.transpiler.source.thir.*
+import com.github.derg.transpiler.utils.*
+
+/**
+ * The value checker ensures that the value examined is valid in the context it is used in.
+ */
+internal class CheckerValue
+{
+    /**
+     * Performs type-checking on the instruction [node]. If there are any type errors detected, an error is returned.
+     */
+    fun check(node: ThirValue): Result<Unit, TypeError> = when (node)
+    {
+        is ThirCall       -> handle(node)
+        is ThirCatch      -> TODO()
+        is ThirLoad       -> TODO()
+        is ThirValueBool  -> Unit.toSuccess()
+        is ThirValueInt32 -> Unit.toSuccess()
+        is ThirValueInt64 -> Unit.toSuccess()
+    }
+    
+    private fun handle(node: ThirCall): Result<Unit, TypeError>
+    {
+        // Call instances cannot evaluate to an error type.
+        if (node.instance.error != null)
+            return TypeError.CallContainsError(node.instance).toFailure()
+        
+        // The instance must evaluate to a callable type.
+        if (node.instance.value == null)
+            return TypeError.CallMissingValue(node.instance).toFailure()
+        if (node.instance.value !is ThirTypeCall)
+            return TypeError.CallWrongType(node.instance).toFailure()
+        
+        // TODO: Support callable structs.
+        return Unit.toSuccess()
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -47,6 +47,24 @@ class TestCheckerInstructions
             
             assertFailure(TypeError.AssignMissingValue(input), checker.check(variable.thirAssign(input)))
         }
+    
+        @Test
+        fun `Given valid value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+            
+            assertSuccess(Unit, checker.check(variable.thirAssign(input)))
+        }
+        
+        @Test
+        fun `Given invalid value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+    
+            assertFailure(TypeError.CallContainsError(instance), checker.check(variable.thirAssign(input)))
+        }
     }
     
     @Nested

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -103,6 +103,24 @@ class TestCheckerInstructions
             
             assertFailure(TypeError.BranchMissingValue(input), checker.check(input.thirBranch()))
         }
+    
+        @Test
+        fun `Given valid value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertSuccess(Unit, checker.check(input.thirBranch()))
+        }
+    
+        @Test
+        fun `Given invalid value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertFailure(TypeError.CallContainsError(instance), checker.check(input.thirBranch()))
+        }
     }
     
     @Nested

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -242,6 +242,24 @@ class TestCheckerInstructions
             
             assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnValue))
         }
+    
+        @Test
+        fun `Given valid value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertSuccess(Unit, checkerValue.check(input.thirReturnValue))
+        }
+    
+        @Test
+        fun `Given invalid value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertFailure(TypeError.CallContainsError(instance), checkerValue.check(input.thirReturnValue))
+        }
     }
     
     @Nested
@@ -288,6 +306,24 @@ class TestCheckerInstructions
             val input = thirFunOf(value = bool).thirCall()
             
             assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnError))
+        }
+    
+        @Test
+        fun `Given valid value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertSuccess(Unit, checkerError.check(input.thirReturnError))
+        }
+    
+        @Test
+        fun `Given invalid value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertFailure(TypeError.CallContainsError(instance), checkerError.check(input.thirReturnError))
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -151,6 +151,24 @@ class TestCheckerInstructions
             
             assertFailure(TypeError.EvaluateContainsError(input), checker.check(input.thirEval))
         }
+    
+        @Test
+        fun `Given valid value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(), error = null).thirCall()
+            val input = instance.thirCall(value = null, error = null)
+        
+            assertSuccess(Unit, checker.check(input.thirEval))
+        }
+    
+        @Test
+        fun `Given invalid value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(), error = int32).thirCall()
+            val input = instance.thirCall(value = null, error = null)
+        
+            assertFailure(TypeError.CallContainsError(instance), checker.check(input.thirEval))
+        }
     }
     
     @Nested

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerValues.kt
@@ -1,0 +1,52 @@
+package com.github.derg.transpiler.phases.typechecker
+
+import com.github.derg.transpiler.phases.typechecker.TypeError.*
+import com.github.derg.transpiler.source.hir.*
+import com.github.derg.transpiler.source.thir.*
+import com.github.derg.transpiler.utils.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class TestCheckerValues
+{
+    private val bool = thirTypeData(Builtin.BOOL.id)
+    private val func = thirTypeCall()
+    
+    @Nested
+    inner class Call
+    {
+        private val checker = CheckerValue()
+    
+        @Test
+        fun `Given no type, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = null, error = null).thirCall()
+    
+            assertFailure(CallMissingValue(instance), checker.check(instance.thirCall()))
+        }
+    
+        @Test
+        fun `Given valid type, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = func, error = null).thirCall()
+        
+            assertSuccess(Unit, checker.check(instance.thirCall()))
+        }
+        
+        @Test
+        fun `Given invalid type, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = bool, error = null).thirCall()
+    
+            assertFailure(CallWrongType(instance), checker.check(instance.thirCall()))
+        }
+    
+        @Test
+        fun `Given error type, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = func, error = bool).thirCall()
+        
+            assertFailure(CallContainsError(instance), checker.check(instance.thirCall()))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -96,6 +96,7 @@ val ThirVariable.thirLoad: ThirValue get() = ThirLoad(type, id, emptyList())
 val ThirParameter.thirLoad: ThirValue get() = ThirLoad(type, id, emptyList())
 val ThirFunction.thirLoad: ThirValue get() = ThirLoad(type, id, emptyList())
 fun ThirFunction.thirCall(vararg parameters: Any) = ThirCall(type.value, type.error, thirLoad, parameters.map { it.thir })
+fun ThirValue.thirCall(value: ThirType? = null, error: ThirType? = null, parameters: List<ThirValue> = emptyList()) = ThirCall(value, error, this, parameters)
 
 ///////////////////////
 // Statement helpers //


### PR DESCRIPTION
This pull request introduces a type-checker for expressions. This checker allows expressions to be examined for mistakes, preventing type-errors from sneaking in via values in the program, where the statement type-checking is not quite adequate.