### PR TITLE
147 implement type-checker when capturing an error and handling it

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -72,6 +72,21 @@ sealed interface TypeError
     data class CallContainsError(val instance: ThirValue) : TypeError
     
     /**
+     * The catch [instance] does not evaluate to something which has any value type.
+     */
+    data class CatchMissingValue(val instance: ThirValue) : TypeError
+    
+    /**
+     * The catch [instance] does not evaluate to something which has any error type.
+     */
+    data class CatchMissingError(val instance: ThirValue) : TypeError
+    
+    /**
+     * The catch [instance] is evaluated to a possible error type, which is not permitted.
+     */
+    data class CatchContainsError(val instance: ThirValue) : TypeError
+    
+    /**
      * The provided [expression] is evaluated to a possible value, which is not permitted.
      */
     data class EvaluateContainsValue(val expression: ThirValue) : TypeError

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.typechecker
 
+import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 
@@ -14,8 +15,8 @@ internal class CheckerValue
     fun check(node: ThirValue): Result<Unit, TypeError> = when (node)
     {
         is ThirCall       -> handle(node)
-        is ThirCatch      -> TODO()
-        is ThirLoad       -> TODO()
+        is ThirCatch      -> handle(node)
+        is ThirLoad       -> handle(node)
         is ThirValueBool  -> Unit.toSuccess()
         is ThirValueInt32 -> Unit.toSuccess()
         is ThirValueInt64 -> Unit.toSuccess()
@@ -28,12 +29,41 @@ internal class CheckerValue
             return TypeError.CallContainsError(node.instance).toFailure()
         
         // The instance must evaluate to a callable type.
+        // TODO: Support callable structs.
         if (node.instance.value == null)
             return TypeError.CallMissingValue(node.instance).toFailure()
         if (node.instance.value !is ThirTypeCall)
             return TypeError.CallWrongType(node.instance).toFailure()
         
-        // TODO: Support callable structs.
+        // Ensure that all inputs to the call are also valid.
+        check(node.instance).onFailure { return it.toFailure() }
+        node.parameters.mapUntilError { check(it) }.onFailure { return it.toFailure() }
+        return Unit.toSuccess()
+    }
+    
+    private fun handle(node: ThirCatch): Result<Unit, TypeError>
+    {
+        // Both left-hand and right-hand expression must have a valid value.
+        if (node.lhs.value == null && node.capture == Capture.HANDLE)
+            return TypeError.CatchMissingValue(node.lhs).toFailure()
+        if (node.rhs.value == null)
+            return TypeError.CatchMissingValue(node.rhs).toFailure()
+        
+        // The left-hand side must evaluate to an error, whereas the right-hand side cannot.
+        if (node.lhs.error == null)
+            return TypeError.CatchMissingError(node.lhs).toFailure()
+        if (node.rhs.error != null)
+            return TypeError.CatchContainsError(node.rhs).toFailure()
+        
+        // Ensure all inputs to the catch are also valid.
+        check(node.lhs).onFailure { return it.toFailure() }
+        check(node.rhs).onFailure { return it.toFailure() }
+        return Unit.toSuccess()
+    }
+    
+    private fun handle(node: ThirLoad): Result<Unit, TypeError>
+    {
+        // TODO: Implement me.
         return Unit.toSuccess()
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.typechecker
 
+import com.github.derg.transpiler.phases.typechecker.TypeError.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
@@ -29,7 +30,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = thirTypeData()).thirCall()
             
-            assertFailure(TypeError.AssignWrongType(input), checker.check(variable.thirAssign(input)))
+            assertFailure(AssignWrongType(input), checker.check(variable.thirAssign(input)))
         }
         
         @Test
@@ -37,7 +38,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = bool, error = bool).thirCall()
             
-            assertFailure(TypeError.AssignContainsError(input), checker.check(variable.thirAssign(input)))
+            assertFailure(AssignContainsError(input), checker.check(variable.thirAssign(input)))
         }
         
         @Test
@@ -45,7 +46,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = null).thirCall()
             
-            assertFailure(TypeError.AssignMissingValue(input), checker.check(variable.thirAssign(input)))
+            assertFailure(AssignMissingValue(input), checker.check(variable.thirAssign(input)))
         }
     
         @Test
@@ -63,7 +64,7 @@ class TestCheckerInstructions
             val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
     
-            assertFailure(TypeError.CallContainsError(instance), checker.check(variable.thirAssign(input)))
+            assertFailure(CallContainsError(instance), checker.check(variable.thirAssign(input)))
         }
     }
     
@@ -85,7 +86,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = thirTypeData()).thirCall()
             
-            assertFailure(TypeError.BranchWrongType(input), checker.check(input.thirBranch()))
+            assertFailure(BranchWrongType(input), checker.check(input.thirBranch()))
         }
         
         @Test
@@ -93,7 +94,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = bool, error = bool).thirCall()
             
-            assertFailure(TypeError.BranchContainsError(input), checker.check(input.thirBranch()))
+            assertFailure(BranchContainsError(input), checker.check(input.thirBranch()))
         }
         
         @Test
@@ -101,7 +102,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = null).thirCall()
             
-            assertFailure(TypeError.BranchMissingValue(input), checker.check(input.thirBranch()))
+            assertFailure(BranchMissingValue(input), checker.check(input.thirBranch()))
         }
     
         @Test
@@ -119,7 +120,7 @@ class TestCheckerInstructions
             val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
         
-            assertFailure(TypeError.CallContainsError(instance), checker.check(input.thirBranch()))
+            assertFailure(CallContainsError(instance), checker.check(input.thirBranch()))
         }
     }
     
@@ -141,7 +142,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = thirTypeData(), error = null).thirCall()
             
-            assertFailure(TypeError.EvaluateContainsValue(input), checker.check(input.thirEval))
+            assertFailure(EvaluateContainsValue(input), checker.check(input.thirEval))
         }
         
         @Test
@@ -149,7 +150,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = null, error = thirTypeData()).thirCall()
             
-            assertFailure(TypeError.EvaluateContainsError(input), checker.check(input.thirEval))
+            assertFailure(EvaluateContainsError(input), checker.check(input.thirEval))
         }
     
         @Test
@@ -167,7 +168,7 @@ class TestCheckerInstructions
             val instance = thirFunOf(value = thirTypeCall(), error = int32).thirCall()
             val input = instance.thirCall(value = null, error = null)
         
-            assertFailure(TypeError.CallContainsError(instance), checker.check(input.thirEval))
+            assertFailure(CallContainsError(instance), checker.check(input.thirEval))
         }
     }
     
@@ -193,7 +194,7 @@ class TestCheckerInstructions
         @Test
         fun `Given value type, when checking, then correct error`()
         {
-            assertFailure(TypeError.ReturnMissingExpression, checkerValue.check(ThirReturn))
+            assertFailure(ReturnMissingExpression, checkerValue.check(ThirReturn))
         }
     }
     
@@ -216,7 +217,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = int32).thirCall()
             
-            assertFailure(TypeError.ReturnWrongType(input), checkerValue.check(input.thirReturnValue))
+            assertFailure(ReturnWrongType(input), checkerValue.check(input.thirReturnValue))
         }
         
         @Test
@@ -224,7 +225,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = bool, error = bool).thirCall()
             
-            assertFailure(TypeError.ReturnContainsError(input), checkerValue.check(input.thirReturnValue))
+            assertFailure(ReturnContainsError(input), checkerValue.check(input.thirReturnValue))
         }
         
         @Test
@@ -232,7 +233,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = null).thirCall()
             
-            assertFailure(TypeError.ReturnMissingValue(input), checkerValue.check(input.thirReturnValue))
+            assertFailure(ReturnMissingValue(input), checkerValue.check(input.thirReturnValue))
         }
         
         @Test
@@ -240,7 +241,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = bool).thirCall()
             
-            assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnValue))
+            assertFailure(ReturnContainsValue(input), checkerEmpty.check(input.thirReturnValue))
         }
     
         @Test
@@ -258,7 +259,7 @@ class TestCheckerInstructions
             val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
         
-            assertFailure(TypeError.CallContainsError(instance), checkerValue.check(input.thirReturnValue))
+            assertFailure(CallContainsError(instance), checkerValue.check(input.thirReturnValue))
         }
     }
     
@@ -281,7 +282,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = int32).thirCall()
             
-            assertFailure(TypeError.ReturnWrongType(input), checkerError.check(input.thirReturnError))
+            assertFailure(ReturnWrongType(input), checkerError.check(input.thirReturnError))
         }
         
         @Test
@@ -289,7 +290,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = bool, error = bool).thirCall()
             
-            assertFailure(TypeError.ReturnContainsError(input), checkerError.check(input.thirReturnError))
+            assertFailure(ReturnContainsError(input), checkerError.check(input.thirReturnError))
         }
         
         @Test
@@ -297,7 +298,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = null).thirCall()
             
-            assertFailure(TypeError.ReturnMissingValue(input), checkerError.check(input.thirReturnError))
+            assertFailure(ReturnMissingValue(input), checkerError.check(input.thirReturnError))
         }
         
         @Test
@@ -305,7 +306,7 @@ class TestCheckerInstructions
         {
             val input = thirFunOf(value = bool).thirCall()
             
-            assertFailure(TypeError.ReturnContainsValue(input), checkerEmpty.check(input.thirReturnError))
+            assertFailure(ReturnContainsValue(input), checkerEmpty.check(input.thirReturnError))
         }
     
         @Test
@@ -323,7 +324,7 @@ class TestCheckerInstructions
             val instance = thirFunOf(value = thirTypeCall(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
         
-            assertFailure(TypeError.CallContainsError(instance), checkerError.check(input.thirReturnError))
+            assertFailure(CallContainsError(instance), checkerError.check(input.thirReturnError))
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerValues.kt
@@ -48,5 +48,132 @@ class TestCheckerValues
         
             assertFailure(CallContainsError(instance), checker.check(instance.thirCall()))
         }
+    
+        @Test
+        fun `Given valid instance value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(func), error = null).thirCall()
+            val input = instance.thirCall(value = func, error = null)
+        
+            assertSuccess(Unit, checker.check(input.thirCall()))
+        }
+    
+        @Test
+        fun `Given invalid instance value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(func), error = bool).thirCall()
+            val input = instance.thirCall(value = func, error = null)
+        
+            assertFailure(CallContainsError(instance), checker.check(input.thirCall()))
+        }
+    }
+    
+    @Nested
+    inner class Catch
+    {
+        private val checker = CheckerValue()
+    
+        private val neither = thirFunOf(value = null, error = null).thirCall()
+        private val value = thirFunOf(value = bool, error = null).thirCall()
+        private val error = thirFunOf(value = null, error = bool).thirCall()
+        private val both = thirFunOf(value = bool, error = bool).thirCall()
+    
+        @Test
+        fun `Given lhs raise, when checking, then correct outcome`()
+        {
+            assertFailure(CatchMissingError(neither), checker.check(neither thirCatchRaise 0))
+            assertFailure(CatchMissingError(value), checker.check(value thirCatchRaise 0))
+            assertSuccess(Unit, checker.check(error thirCatchRaise 0))
+            assertSuccess(Unit, checker.check(both thirCatchRaise 0))
+        }
+    
+        @Test
+        fun `Given lhs return, when checking, then correct outcome`()
+        {
+            assertFailure(CatchMissingError(neither), checker.check(neither thirCatchReturn 0))
+            assertFailure(CatchMissingError(value), checker.check(value thirCatchReturn 0))
+            assertSuccess(Unit, checker.check(error thirCatchReturn 0))
+            assertSuccess(Unit, checker.check(both thirCatchReturn 0))
+        }
+        
+        @Test
+        fun `Given lhs handle, when checking, then correct outcome`()
+        {
+            assertFailure(CatchMissingValue(neither), checker.check(neither thirCatchHandle 0))
+            assertFailure(CatchMissingError(value), checker.check(value thirCatchHandle 0))
+            assertFailure(CatchMissingValue(error), checker.check(error thirCatchHandle 0))
+            assertSuccess(Unit, checker.check(both thirCatchHandle 0))
+        }
+    
+        @Test
+        fun `Given rhs raise, when checking, then correct outcome`()
+        {
+            assertFailure(CatchMissingValue(neither), checker.check(both thirCatchRaise neither))
+            assertSuccess(Unit, checker.check(both thirCatchRaise value))
+            assertFailure(CatchMissingValue(error), checker.check(both thirCatchRaise error))
+            assertFailure(CatchContainsError(both), checker.check(both thirCatchRaise both))
+        }
+    
+        @Test
+        fun `Given rhs return, when checking, then correct outcome`()
+        {
+            assertFailure(CatchMissingValue(neither), checker.check(both thirCatchReturn neither))
+            assertSuccess(Unit, checker.check(both thirCatchReturn value))
+            assertFailure(CatchMissingValue(error), checker.check(both thirCatchReturn error))
+            assertFailure(CatchContainsError(both), checker.check(both thirCatchReturn both))
+        }
+    
+        @Test
+        fun `Given rhs handle, when checking, then correct outcome`()
+        {
+            assertFailure(CatchMissingValue(neither), checker.check(both thirCatchHandle neither))
+            assertSuccess(Unit, checker.check(both thirCatchHandle value))
+            assertFailure(CatchMissingValue(error), checker.check(both thirCatchHandle error))
+            assertFailure(CatchContainsError(both), checker.check(both thirCatchHandle both))
+        }
+    
+        @Test
+        fun `Given valid lhs value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = bool)
+    
+            assertSuccess(Unit, checker.check(input thirCatchRaise 0))
+            assertSuccess(Unit, checker.check(input thirCatchReturn 0))
+            assertSuccess(Unit, checker.check(input thirCatchHandle 0))
+        }
+    
+        @Test
+        fun `Given invalid lhs value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = bool).thirCall()
+            val input = instance.thirCall(value = bool, error = bool)
+    
+            assertFailure(CallContainsError(instance), checker.check(input thirCatchRaise 0))
+            assertFailure(CallContainsError(instance), checker.check(input thirCatchReturn 0))
+            assertFailure(CallContainsError(instance), checker.check(input thirCatchHandle 0))
+        }
+    
+        @Test
+        fun `Given valid rhs value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertSuccess(Unit, checker.check(both thirCatchRaise input))
+            assertSuccess(Unit, checker.check(both thirCatchReturn input))
+            assertSuccess(Unit, checker.check(both thirCatchHandle input))
+        }
+    
+        @Test
+        fun `Given invalid rhs value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeCall(bool), error = bool).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+        
+            assertFailure(CallContainsError(instance), checker.check(both thirCatchRaise input))
+            assertFailure(CallContainsError(instance), checker.check(both thirCatchReturn input))
+            assertFailure(CallContainsError(instance), checker.check(both thirCatchHandle input))
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces logic for ensuring that error capturing is properly type-checked. Errors are mandatory in the left-hand side expression, whereas they are forbidden in the right-hand side expression. In the raise and return cases, the left-hand side expression may be omitted.