### PR TITLE
149 remove builtin instructions at thir layer

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
@@ -12,18 +12,18 @@ internal val INT32_MAX = Int.MAX_VALUE.toBigInteger()
 internal val INT64_MIN = Long.MIN_VALUE.toBigInteger()
 internal val INT64_MAX = Long.MAX_VALUE.toBigInteger()
 
-private fun BigInteger.toInt32(): Result<ThirInt32Const, ResolveError>
+private fun BigInteger.toInt32(): Result<ThirConstInt32, ResolveError>
 {
     if (this < INT32_MIN || this > INT32_MAX)
         return ResolveError.InvalidLiteralInteger(this).toFailure()
-    return ThirInt32Const(toInt()).toSuccess()
+    return ThirConstInt32(toInt()).toSuccess()
 }
 
-private fun BigInteger.toInt64(): Result<ThirInt64Const, ResolveError>
+private fun BigInteger.toInt64(): Result<ThirConstInt64, ResolveError>
 {
     if (this < INT64_MIN || this > INT64_MAX)
         return ResolveError.InvalidLiteralInteger(this).toFailure()
-    return ThirInt64Const(toLong()).toSuccess()
+    return ThirConstInt64(toLong()).toSuccess()
 }
 
 /**
@@ -45,7 +45,7 @@ internal class ResolverValue(private val types: TypeTable, private val scope: Sc
     {
         is HirAdd     -> handleInfix(Symbol.PLUS, node.lhs, node.rhs)
         is HirAnd     -> handleInfix(Symbol.AND, node.lhs, node.rhs)
-        is HirBool    -> ThirBoolConst(node.value).toSuccess()
+        is HirBool    -> ThirConstBool(node.value).toSuccess()
         is HirCall    -> handleCall(node)
         is HirCatch   -> handleCatch(node)
         is HirDecimal -> TODO()
@@ -153,7 +153,7 @@ internal class ResolverValue(private val types: TypeTable, private val scope: Sc
         
         return when (matching.size)
         {
-            1    -> matching.single().toBuiltin().toSuccess()
+            1    -> matching.single().toSuccess()
             0    -> ResolveError.ArgumentMismatch(node.instance.name, node.parameters).toFailure()
             else -> ResolveError.AmbiguousFunction(node.instance.name, node.parameters).toFailure()
         }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -17,9 +17,9 @@ internal class CheckerValue
         is ThirCall       -> handle(node)
         is ThirCatch      -> handle(node)
         is ThirLoad       -> handle(node)
-        is ThirValueBool  -> Unit.toSuccess()
-        is ThirValueInt32 -> Unit.toSuccess()
-        is ThirValueInt64 -> Unit.toSuccess()
+        is ThirConstBool  -> Unit.toSuccess()
+        is ThirConstInt32 -> Unit.toSuccess()
+        is ThirConstInt64 -> Unit.toSuccess()
     }
     
     private fun handle(node: ThirCall): Result<Unit, TypeError>

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
@@ -54,132 +54,26 @@ data class ThirCatch(val lhs: ThirValue, val rhs: ThirValue, val capture: Captur
 /**
  * Boolean values, `true` and `false`.
  */
-sealed interface ThirValueBool : ThirValue
+data class ThirConstBool(val raw: Boolean) : ThirValue
 {
     override val value: ThirType get() = ThirTypeData(Builtin.BOOL.id, Mutability.IMMUTABLE, emptyList())
     override val error: Nothing? get() = null
 }
 
-data class ThirBoolConst(val raw: Boolean) : ThirValueBool
-data class ThirBoolEq(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirBoolNe(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirBoolAnd(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirBoolOr(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirBoolXor(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirBoolNot(val rhs: ThirValue) : ThirValueBool
-
 /**
  * 32-bit signed integers.
  */
-sealed interface ThirValueInt32 : ThirValue
+data class ThirConstInt32(val raw: Int) : ThirValue
 {
     override val value: ThirType get() = ThirTypeData(Builtin.INT32.id, Mutability.IMMUTABLE, emptyList())
-    override val error: ThirType?
-        get() = when (this)
-        {
-            is ThirInt32Div -> ThirTypeData(Builtin.DIVIDE_BY_ZERO.id, Mutability.IMMUTABLE, emptyList())
-            is ThirInt32Mod -> ThirTypeData(Builtin.DIVIDE_BY_ZERO.id, Mutability.IMMUTABLE, emptyList())
-            else            -> null
-        }
+    override val error: Nothing? get() = null
 }
-
-data class ThirInt32Const(val raw: Int) : ThirValueInt32
-data class ThirInt32Eq(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt32Ne(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt32Le(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt32Lt(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt32Ge(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt32Gt(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt32Add(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt32
-data class ThirInt32Sub(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt32
-data class ThirInt32Mul(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt32
-data class ThirInt32Div(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt32
-data class ThirInt32Mod(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt32
-data class ThirInt32Neg(val rhs: ThirValue) : ThirValueInt32
 
 /**
  * 64-bit signed integers.
  */
-sealed interface ThirValueInt64 : ThirValue
+data class ThirConstInt64(val raw: Long) : ThirValue
 {
     override val value: ThirType get() = ThirTypeData(Builtin.INT64.id, Mutability.IMMUTABLE, emptyList())
-    override val error: ThirType?
-        get() = when (this)
-        {
-            is ThirInt64Div -> ThirTypeData(Builtin.DIVIDE_BY_ZERO.id, Mutability.IMMUTABLE, emptyList())
-            is ThirInt64Mod -> ThirTypeData(Builtin.DIVIDE_BY_ZERO.id, Mutability.IMMUTABLE, emptyList())
-            else            -> null
-        }
-}
-
-data class ThirInt64Const(val raw: Long) : ThirValueInt64
-data class ThirInt64Eq(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt64Ne(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt64Le(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt64Lt(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt64Ge(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt64Gt(val lhs: ThirValue, val rhs: ThirValue) : ThirValueBool
-data class ThirInt64Add(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt64
-data class ThirInt64Sub(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt64
-data class ThirInt64Mul(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt64
-data class ThirInt64Div(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt64
-data class ThirInt64Mod(val lhs: ThirValue, val rhs: ThirValue) : ThirValueInt64
-data class ThirInt64Neg(val rhs: ThirValue) : ThirValueInt64
-
-/**
- * Returns a builtin function which does the same as [this] function call, iff a builtin function exists for it.
- * Otherwise, [this] is returned.
- *
- * Note that the builtin functions must be correctly declared (i.e. types and return values are in proper order). Make
- * sure to keep the builtin functions up-to-date with these builtin values.
- */
-internal fun ThirCall.toBuiltin(): ThirValue
-{
-    // Cannot inline and optimize function calls that are located somewhere in memory.
-    if (instance !is ThirLoad)
-        return this
-    
-    return when (instance.symbolId)
-    {
-        // Bool
-        Builtin.BOOL_AND.id  -> ThirBoolAnd(parameters[0], parameters[1])
-        Builtin.BOOL_EQ.id   -> ThirBoolEq(parameters[0], parameters[1])
-        Builtin.BOOL_NE.id   -> ThirBoolNe(parameters[0], parameters[1])
-        Builtin.BOOL_NOT.id  -> ThirBoolNot(parameters[0])
-        Builtin.BOOL_OR.id   -> ThirBoolOr(parameters[0], parameters[1])
-        Builtin.BOOL_XOR.id  -> ThirBoolXor(parameters[0], parameters[1])
-        
-        // Int32
-        Builtin.INT32_EQ.id  -> ThirInt32Eq(parameters[0], parameters[1])
-        Builtin.INT32_GE.id  -> ThirInt32Ge(parameters[0], parameters[1])
-        Builtin.INT32_GT.id  -> ThirInt32Gt(parameters[0], parameters[1])
-        Builtin.INT32_LE.id  -> ThirInt32Le(parameters[0], parameters[1])
-        Builtin.INT32_LT.id  -> ThirInt32Lt(parameters[0], parameters[1])
-        Builtin.INT32_NE.id  -> ThirInt32Ne(parameters[0], parameters[1])
-        Builtin.INT32_ADD.id -> ThirInt32Add(parameters[0], parameters[1])
-        Builtin.INT32_DIV.id -> ThirInt32Div(parameters[0], parameters[1])
-        Builtin.INT32_MOD.id -> ThirInt32Mod(parameters[0], parameters[1])
-        Builtin.INT32_MUL.id -> ThirInt32Mul(parameters[0], parameters[1])
-        Builtin.INT32_NEG.id -> ThirInt32Neg(parameters[0])
-        Builtin.INT32_POS.id -> parameters[0]
-        Builtin.INT32_SUB.id -> ThirInt32Sub(parameters[0], parameters[1])
-        
-        // Int64
-        Builtin.INT64_EQ.id  -> ThirInt64Eq(parameters[0], parameters[1])
-        Builtin.INT64_GE.id  -> ThirInt64Ge(parameters[0], parameters[1])
-        Builtin.INT64_GT.id  -> ThirInt64Gt(parameters[0], parameters[1])
-        Builtin.INT64_LE.id  -> ThirInt64Le(parameters[0], parameters[1])
-        Builtin.INT64_LT.id  -> ThirInt64Lt(parameters[0], parameters[1])
-        Builtin.INT64_NE.id  -> ThirInt64Ne(parameters[0], parameters[1])
-        Builtin.INT64_ADD.id -> ThirInt64Add(parameters[0], parameters[1])
-        Builtin.INT64_DIV.id -> ThirInt64Div(parameters[0], parameters[1])
-        Builtin.INT64_MOD.id -> ThirInt64Mod(parameters[0], parameters[1])
-        Builtin.INT64_MUL.id -> ThirInt64Mul(parameters[0], parameters[1])
-        Builtin.INT64_NEG.id -> ThirInt64Neg(parameters[0])
-        Builtin.INT64_POS.id -> parameters[0]
-        Builtin.INT64_SUB.id -> ThirInt64Sub(parameters[0], parameters[1])
-        
-        // Custom function
-        else                 -> this
-    }
+    override val error: Nothing? get() = null
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
@@ -619,8 +619,8 @@ class TestResolverValue
         @Test
         fun `Given builtin types, when resolving, then correct outcome`()
         {
-            assertSuccess(1.thir, run(1.hirPlus))
-            assertSuccess(1L.thir, run(1L.hirPlus))
+            assertSuccess(1.thirPlus, run(1.hirPlus))
+            assertSuccess(1L.thirPlus, run(1L.hirPlus))
         }
         
         @Test

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -57,6 +57,10 @@ fun hirTypeUnion(vararg types: HirType) = HirTypeUnion(types.toList())
 // Expression helpers //
 ////////////////////////
 
+val Any.hirNot: HirValue get() = HirNot(hir)
+val Any.hirPlus: HirValue get() = HirPlus(hir)
+val Any.hirMinus: HirValue get() = HirMinus(hir)
+
 infix fun Any.hirEq(that: Any): HirValue = HirEq(this.hir, that.hir)
 infix fun Any.hirNe(that: Any): HirValue = HirNe(this.hir, that.hir)
 infix fun Any.hirGe(that: Any): HirValue = HirGe(this.hir, that.hir)
@@ -77,10 +81,6 @@ infix fun Any.hirXor(that: Any): HirValue = HirXor(this.hir, that.hir)
 infix fun Any.hirCatchRaise(that: Any) = HirCatch(this.hir, that.hir, Capture.RAISE)
 infix fun Any.hirCatchReturn(that: Any) = HirCatch(this.hir, that.hir, Capture.RETURN)
 infix fun Any.hirCatchHandle(that: Any) = HirCatch(this.hir, that.hir, Capture.HANDLE)
-
-val Any.hirNot: HirValue get() = HirNot(hir)
-val Any.hirMinus: HirValue get() = HirMinus(hir)
-val Any.hirPlus: HirValue get() = HirPlus(hir)
 
 val HirSymbol.hirLoad: HirValue get() = HirLoad(name, emptyList())
 fun HirFunction.hirCall(vararg parameters: Any) = HirCall(hirLoad, parameters.map { null hirArg it })


### PR DESCRIPTION
This pull request removes the existence of the low-level instructions targeting specific data types. These instructions should be introduced at a lower layer, i.e. MIR or even lower. The presence of them makes it harder to write a unified THIR layer, where everything can be normalized into a smaller core language. Removing the special instructions enable a simpler language based on function calls instead. Since we have the id of every function, we are able to convert to specialized instructions at a later point.