### PR TITLE
Replace thir literal with thir function

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -27,7 +27,7 @@ private fun module(name: String, segments: List<AstSegment>) = HirModule(
 /**
  *
  */
-private fun AstType.toHir() = HirTypeData(
+private fun AstType.toHir() = HirTypeStruct(
     name = name,
     generics = emptyList(),
     mutability = mutability,
@@ -50,7 +50,7 @@ internal fun AstConstant.toHir() = HirConstant(
 internal fun AstFunction.toHir() = HirFunction(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeCall(
+    type = HirTypeFunction(
         value = valueType?.toHir(),
         error = errorType?.toHir(),
         parameters = parameters.map { it.name to it.type.toHir() },

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
@@ -3,7 +3,7 @@ package com.github.derg.transpiler.phases.resolver
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
-import java.math.BigInteger
+import java.math.*
 
 /**
  * Converts the input [hirPackage] into a typed variable. All symbols found within the package are stored in the symbol

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
@@ -81,17 +81,18 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
 //        node.variables.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
         handle(node.parameter).onFailure { return it.toFailure() }
         
-        val symbol = ThirLiteral(
+        val symbol = ThirFunction(
             id = node.id,
             name = node.name,
             type = types.literals[node.id]!!,
             visibility = node.visibility,
             instructions = node.instructions.mapUntilError { instructions.resolve(it) }.valueOr { return it.toFailure() },
+            genericIds = emptySet(),
             variableIds = node.variables.map { it.id }.toSet(),
-            parameterId = node.parameter.id,
+            parameterIds = setOf(node.parameter.id),
         )
         
-        symbols.literals[symbol.id] = symbol
+        symbols.functions[symbol.id] = symbol
         return symbol.toSuccess()
     }
     

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverTypes.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverTypes.kt
@@ -17,12 +17,12 @@ internal class ResolverType(private val scope: Scope)
      */
     fun resolve(type: HirType): Result<ThirType, ResolveError> = when (type)
     {
-        is HirTypeCall  -> resolve(type)
-        is HirTypeData  -> resolve(type)
-        is HirTypeUnion -> resolve(type)
+        is HirTypeFunction -> resolve(type)
+        is HirTypeStruct   -> resolve(type)
+        is HirTypeUnion    -> resolve(type)
     }
     
-    fun resolve(type: HirTypeData): Result<ThirTypeData, ResolveError>
+    fun resolve(type: HirTypeStruct): Result<ThirTypeStruct, ResolveError>
     {
         // TODO: This way of resolving the typed information does not take generics into consideration. We need to match
         //       all provided generics towards all potential candidates, taking names and ordering into consideration.
@@ -34,16 +34,16 @@ internal class ResolverType(private val scope: Scope)
             else -> return ResolveError.AmbiguousStruct(type.name).toFailure()
         }
         
-        return ThirTypeData(symbolId = candidate.id, generics = emptyList(), mutability = type.mutability).toSuccess()
+        return ThirTypeStruct(symbolId = candidate.id, generics = emptyList(), mutability = type.mutability).toSuccess()
     }
     
-    fun resolve(type: HirTypeCall): Result<ThirTypeCall, ResolveError>
+    fun resolve(type: HirTypeFunction): Result<ThirTypeFunction, ResolveError>
     {
         val value = type.value?.let { resolve(it) }?.valueOr { return it.toFailure() }
         val error = type.error?.let { resolve(it) }?.valueOr { return it.toFailure() }
         val parameters = type.parameters.mapUntilError { handle(it) }.valueOr { return it.toFailure() }
         
-        return ThirTypeCall(value = value, error = error, parameters = parameters).toSuccess()
+        return ThirTypeFunction(value = value, error = error, parameters = parameters).toSuccess()
     }
     
     fun resolve(type: HirTypeUnion): Result<ThirType, ResolveError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
@@ -97,7 +97,7 @@ internal class ResolverValue(private val types: TypeTable, private val scope: Sc
      * valid candidate for being invoked with the parameters, a function call value is generated. Note that multiple
      * functions may be valid, which is the case when the function call is ambiguous.
      */
-    private fun resolveCall(id: UUID, type: ThirTypeCall, inputs: List<NamedMaybe<ThirValue>>): Result<ThirCall, ResolveError>
+    private fun resolveCall(id: UUID, type: ThirTypeFunction, inputs: List<NamedMaybe<ThirValue>>): Result<ThirCall, ResolveError>
     {
         // TODO: Support variadic arguments.
         if (type.parameters.size != inputs.size)
@@ -186,7 +186,7 @@ internal class ResolverValue(private val types: TypeTable, private val scope: Sc
         //       and the parameter must be a builtin integer type.
         val literal = types.literals[candidate.id]!!
         val parameter = literal.parameters.singleOrNull() ?: return ResolveError.Placeholder.toFailure()
-        val value = when ((parameter.second as? ThirTypeData)?.symbolId)
+        val value = when ((parameter.second as? ThirTypeStruct)?.symbolId)
         {
             Builtin.INT32.id -> node.value.toInt32().valueOr { return it.toFailure() }
             Builtin.INT64.id -> node.value.toInt64().valueOr { return it.toFailure() }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
@@ -185,8 +185,7 @@ internal class ResolverValue(private val types: TypeTable, private val scope: Sc
         // TODO: Replace invalid parameter error with something more appropriate. We must have exactly one parameter,
         //       and the parameter must be a builtin integer type.
         val literal = types.literals[candidate.id]!!
-        val parameter = literal.parameters.singleOrNull() ?: return ResolveError.Placeholder.toFailure()
-        val value = when ((parameter.second as? ThirTypeStruct)?.symbolId)
+        val value = when (literal.parameter.symbolId)
         {
             Builtin.INT32.id -> node.value.toInt32().valueOr { return it.toFailure() }
             Builtin.INT64.id -> node.value.toInt64().valueOr { return it.toFailure() }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverValues.kt
@@ -1,10 +1,10 @@
 package com.github.derg.transpiler.phases.resolver
 
-import com.github.derg.transpiler.source.Symbol
+import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
-import java.math.BigInteger
+import java.math.*
 import java.util.*
 
 internal val INT32_MIN = Int.MIN_VALUE.toBigInteger()

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Tables.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Tables.kt
@@ -11,14 +11,13 @@ class SymbolTable
 {
     val fields = mutableMapOf<UUID, ThirField>()
     val functions = mutableMapOf<UUID, ThirFunction>()
-    val literals = mutableMapOf<UUID, ThirLiteral>()
     val parameters = mutableMapOf<UUID, ThirParameter>()
     val structs = mutableMapOf<UUID, ThirStruct>()
     val variables = mutableMapOf<UUID, ThirVariable>()
     
     override fun toString(): String
     {
-        return "SymbolTable(\n\tfields=${fields.values},\n\tfunctions=${functions.values},\n\tliterals=${literals.values},\n\tparameters=${parameters.values},\n\tstructs=${structs.values},\n\tvariables=${variables.values})"
+        return "SymbolTable(\n\tfields=${fields.values},\n\tfunctions=${functions.values},\n\tparameters=${parameters.values},\n\tstructs=${structs.values},\n\tvariables=${variables.values})"
     }
 }
 
@@ -30,7 +29,7 @@ class TypeTable
 {
     val fields = mutableMapOf<UUID, ThirType>()
     val functions = mutableMapOf<UUID, ThirTypeFunction>()
-    val literals = mutableMapOf<UUID, ThirTypeFunction>()
+    val literals = mutableMapOf<UUID, ThirTypeLiteral>()
     val parameters = mutableMapOf<UUID, ThirType>()
     val variables = mutableMapOf<UUID, ThirType>()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Tables.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Tables.kt
@@ -29,8 +29,8 @@ class SymbolTable
 class TypeTable
 {
     val fields = mutableMapOf<UUID, ThirType>()
-    val functions = mutableMapOf<UUID, ThirTypeCall>()
-    val literals = mutableMapOf<UUID, ThirTypeCall>()
+    val functions = mutableMapOf<UUID, ThirTypeFunction>()
+    val literals = mutableMapOf<UUID, ThirTypeFunction>()
     val parameters = mutableMapOf<UUID, ThirType>()
     val variables = mutableMapOf<UUID, ThirType>()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -12,7 +12,11 @@ fun check(table: SymbolTable): Result<Unit, TypeError>
 {
     for (function in table.functions.values)
     {
-        val checker = CheckerInstruction(function.type.value, function.type.error)
+        val checker = when (function.type)
+        {
+            is ThirTypeFunction -> CheckerInstruction(function.type.value, function.type.error)
+            is ThirTypeLiteral  -> CheckerInstruction(function.type.value, null)
+        }
         
         function.instructions.mapUntilError { checker.check(it) }.valueOr { return it.toFailure() }
     }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -49,7 +49,7 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         
         // The value type must be boolean.
         val value = node.predicate.value ?: return TypeError.BranchMissingValue(node.predicate).toFailure()
-        if (value !is ThirTypeData || value.symbolId != Builtin.BOOL.id)
+        if (value !is ThirTypeStruct || value.symbolId != Builtin.BOOL.id)
             return TypeError.BranchWrongType(node.predicate).toFailure()
     
         return CheckerValue().check(node.predicate)

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -32,7 +32,7 @@ internal class CheckerValue
         // TODO: Support callable structs.
         if (node.instance.value == null)
             return TypeError.CallMissingValue(node.instance).toFailure()
-        if (node.instance.value !is ThirTypeCall)
+        if (node.instance.value !is ThirTypeFunction)
             return TypeError.CallWrongType(node.instance).toFailure()
         
         // Parameters are not permitted to have errors.

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
@@ -1,6 +1,6 @@
 package com.github.derg.transpiler.source.hir
 
-import com.github.derg.transpiler.phases.resolver.Scope
+import com.github.derg.transpiler.phases.resolver.*
 import com.github.derg.transpiler.source.*
 import java.util.*
 

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
@@ -72,7 +72,7 @@ object Builtin
 /**
  * Generates a type based on the [struct].
  */
-private fun typeOf(struct: HirStruct) = HirTypeData(
+private fun typeOf(struct: HirStruct) = HirTypeStruct(
     name = struct.name,
     generics = emptyList(),
     mutability = Mutability.IMMUTABLE,
@@ -94,10 +94,10 @@ private fun registerStruct(name: String) = HirStruct(
  * Defines a new literal with the given [name] and [parameter]. The literal will return the same type as the parameter
  * itself.
  */
-private fun registerLiteral(name: String, parameter: HirTypeData) = HirLiteral(
+private fun registerLiteral(name: String, parameter: HirTypeStruct) = HirLiteral(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeCall(value = parameter, error = null, parameters = listOf("" to parameter)),
+    type = HirTypeFunction(value = parameter, error = null, parameters = listOf("" to parameter)),
     visibility = Visibility.EXPORTED,
     instructions = emptyList(),
     variables = emptyList(),
@@ -111,7 +111,7 @@ private fun registerLiteral(name: String, parameter: HirTypeData) = HirLiteral(
 private fun registerInfixOp(operator: Symbol, parameter: HirType, value: HirType, error: HirType?) = HirFunction(
     id = UUID.randomUUID(),
     name = operator.symbol,
-    type = HirTypeCall(
+    type = HirTypeFunction(
         value = value,
         error = error,
         parameters = listOf("lhs" to parameter, "rhs" to parameter),
@@ -130,7 +130,7 @@ private fun registerInfixOp(operator: Symbol, parameter: HirType, value: HirType
 private fun registerPrefixOp(operator: Symbol, parameter: HirType, value: HirType, error: HirType?) = HirFunction(
     id = UUID.randomUUID(),
     name = operator.symbol,
-    type = HirTypeCall(
+    type = HirTypeFunction(
         value = value,
         error = error,
         parameters = listOf("rhs" to parameter),

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
@@ -97,7 +97,7 @@ private fun registerStruct(name: String) = HirStruct(
 private fun registerLiteral(name: String, parameter: HirTypeStruct) = HirLiteral(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeFunction(value = parameter, error = null, parameters = listOf("" to parameter)),
+    type = HirTypeLiteral(value = parameter, parameter = parameter),
     visibility = Visibility.EXPORTED,
     instructions = emptyList(),
     variables = emptyList(),

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
@@ -112,7 +112,7 @@ data class HirMethod(
 data class HirLiteral(
     override val id: UUID,
     override val name: String,
-    val type: HirTypeFunction,
+    val type: HirTypeLiteral,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
@@ -78,7 +78,7 @@ data class HirConcept(
 data class HirFunction(
     override val id: UUID,
     override val name: String,
-    val type: HirTypeCall,
+    val type: HirTypeFunction,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     
@@ -95,7 +95,7 @@ data class HirFunction(
 data class HirMethod(
     override val id: UUID,
     override val name: String,
-    val type: HirTypeCall,
+    val type: HirTypeFunction,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     
@@ -112,7 +112,7 @@ data class HirMethod(
 data class HirLiteral(
     override val id: UUID,
     override val name: String,
-    val type: HirTypeCall,
+    val type: HirTypeFunction,
     val visibility: Visibility,
     val instructions: List<HirInstruction>,
     

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
@@ -14,13 +14,13 @@ sealed interface HirType
  * The struct type describes a concrete type by [name], which may be specialized with any number of [generics]. The data
  * within the type has a certain [mutability], indicating whether the type is internally mutable or not.
  */
-data class HirTypeData(val name: String, val mutability: Mutability, val generics: List<Named<HirType>>) : HirType
+data class HirTypeStruct(val name: String, val mutability: Mutability, val generics: List<Named<HirType>>) : HirType
 
 /**
  * The function type describes a function returning a [value] and [error] type, with any number of [parameters]. The
  * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
  */
-data class HirTypeCall(val value: HirType?, val error: HirType?, val parameters: List<Named<HirType>>) : HirType
+data class HirTypeFunction(val value: HirType?, val error: HirType?, val parameters: List<Named<HirType>>) : HirType
 
 /**
  * The union type describes a type which is one of the specified [types]. Any type can be in a union with a union type,

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Types.kt
@@ -23,6 +23,12 @@ data class HirTypeStruct(val name: String, val mutability: Mutability, val gener
 data class HirTypeFunction(val value: HirType?, val error: HirType?, val parameters: List<Named<HirType>>) : HirType
 
 /**
+ * The literal type describes a literal returning a [value] type, taking in exactly one [parameter]. The parameter is
+ * required to have a valid value, and is not permitted to have any error type associated with it.
+ */
+data class HirTypeLiteral(val value: HirType, val parameter: HirTypeStruct) : HirType
+
+/**
  * The union type describes a type which is one of the specified [types]. Any type can be in a union with a union type,
  * although the set of potential types is collapsed into a single set.
  */

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Symbols.kt
@@ -83,7 +83,7 @@ data class ThirConcept(
 data class ThirFunction(
     override val id: UUID,
     override val name: String,
-    val type: ThirTypeCall,
+    val type: ThirTypeFunction,
     val visibility: Visibility,
     val instructions: List<ThirInstruction>,
     
@@ -102,7 +102,7 @@ data class ThirFunction(
 data class ThirLiteral(
     override val id: UUID,
     override val name: String,
-    val type: ThirTypeCall,
+    val type: ThirTypeFunction,
     val visibility: Visibility,
     val instructions: List<ThirInstruction>,
     
@@ -118,7 +118,7 @@ data class ThirLiteral(
 data class ThirMethod(
     override val id: UUID,
     override val name: String,
-    val type: ThirTypeCall,
+    val type: ThirTypeFunction,
     val visibility: Visibility,
     val instructions: List<ThirInstruction>,
     

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Symbols.kt
@@ -83,42 +83,7 @@ data class ThirConcept(
 data class ThirFunction(
     override val id: UUID,
     override val name: String,
-    val type: ThirTypeFunction,
-    val visibility: Visibility,
-    val instructions: List<ThirInstruction>,
-    
-    // Symbols present within the object
-    val genericIds: Set<UUID>,
-    val variableIds: Set<UUID>,
-    val parameterIds: Set<UUID>,
-) : ThirSymbol
-
-/**
- * Literals are a special case of functions. In order to convert from an arbitrary constant value written into the
- * source code (i.e. any number or string), the value may be annotated with a literal which indicates how the constant
- * value should be interpreted. Literals are functions which accept exactly a single parameter, which must be of a
- * predefined set of legal types.
- */
-data class ThirLiteral(
-    override val id: UUID,
-    override val name: String,
-    val type: ThirTypeFunction,
-    val visibility: Visibility,
-    val instructions: List<ThirInstruction>,
-    
-    // Symbols present within the object
-    val variableIds: Set<UUID>,
-    val parameterId: UUID,
-) : ThirSymbol
-
-/**
- * TODO: Write me
- */
-// TODO: Add something which describes the "self" parameter, const-correctness, and such.
-data class ThirMethod(
-    override val id: UUID,
-    override val name: String,
-    val type: ThirTypeFunction,
+    val type: ThirTypeCall,
     val visibility: Visibility,
     val instructions: List<ThirInstruction>,
     

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
@@ -10,6 +10,7 @@ import java.util.*
  * must have the option of specifying the type when it is ambiguous.
  */
 sealed interface ThirType
+sealed interface ThirTypeCall : ThirType
 
 /**
  * The struct type describes a concrete type by [symbolId], which may be specialized with any number of [generics].
@@ -20,7 +21,13 @@ data class ThirTypeStruct(val symbolId: UUID, val mutability: Mutability, val ge
  * The function type describes a function returning a [value] and [error] type, with any number of [parameters]. The
  * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
  */
-data class ThirTypeFunction(val value: ThirType?, val error: ThirType?, val parameters: List<Named<ThirType>>) : ThirType
+data class ThirTypeFunction(val value: ThirType?, val error: ThirType?, val parameters: List<Named<ThirType>>) : ThirTypeCall
+
+/**
+ * The literal type describes a literal returning a [value] type, taking in exactly one [parameter]. The parameter is
+ * required to have a valid value, and is not permitted to have any error type associated with it.
+ */
+data class ThirTypeLiteral(val value: ThirType, val parameter: ThirTypeStruct) : ThirTypeCall
 
 /**
  * The union type describes a type which is one of the specified [types]. Any type can be in a union with a union type,

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Types.kt
@@ -14,13 +14,13 @@ sealed interface ThirType
 /**
  * The struct type describes a concrete type by [symbolId], which may be specialized with any number of [generics].
  */
-data class ThirTypeData(val symbolId: UUID, val mutability: Mutability, val generics: List<Named<ThirType>>) : ThirType
+data class ThirTypeStruct(val symbolId: UUID, val mutability: Mutability, val generics: List<Named<ThirType>>) : ThirType
 
 /**
  * The function type describes a function returning a [value] and [error] type, with any number of [parameters]. The
  * parameters are required to have a valid value, and are not permitted to have any error type associated with them.
  */
-data class ThirTypeCall(val value: ThirType?, val error: ThirType?, val parameters: List<Named<ThirType>>) : ThirType
+data class ThirTypeFunction(val value: ThirType?, val error: ThirType?, val parameters: List<Named<ThirType>>) : ThirType
 
 /**
  * The union type describes a type which is one of the specified [types]. Any type can be in a union with a union type,

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
@@ -1,8 +1,7 @@
 package com.github.derg.transpiler.source.thir
 
-import com.github.derg.transpiler.source.Capture
-import com.github.derg.transpiler.source.Mutability
-import com.github.derg.transpiler.source.hir.Builtin
+import com.github.derg.transpiler.source.*
+import com.github.derg.transpiler.source.hir.*
 import java.util.*
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
@@ -56,7 +56,7 @@ data class ThirCatch(val lhs: ThirValue, val rhs: ThirValue, val capture: Captur
  */
 data class ThirConstBool(val raw: Boolean) : ThirValue
 {
-    override val value: ThirType get() = ThirTypeData(Builtin.BOOL.id, Mutability.IMMUTABLE, emptyList())
+    override val value: ThirType get() = ThirTypeStruct(Builtin.BOOL.id, Mutability.IMMUTABLE, emptyList())
     override val error: Nothing? get() = null
 }
 
@@ -65,7 +65,7 @@ data class ThirConstBool(val raw: Boolean) : ThirValue
  */
 data class ThirConstInt32(val raw: Int) : ThirValue
 {
-    override val value: ThirType get() = ThirTypeData(Builtin.INT32.id, Mutability.IMMUTABLE, emptyList())
+    override val value: ThirType get() = ThirTypeStruct(Builtin.INT32.id, Mutability.IMMUTABLE, emptyList())
     override val error: Nothing? get() = null
 }
 
@@ -74,6 +74,6 @@ data class ThirConstInt32(val raw: Int) : ThirValue
  */
 data class ThirConstInt64(val raw: Long) : ThirValue
 {
-    override val value: ThirType get() = ThirTypeData(Builtin.INT64.id, Mutability.IMMUTABLE, emptyList())
+    override val value: ThirType get() = ThirTypeStruct(Builtin.INT64.id, Mutability.IMMUTABLE, emptyList())
     override val error: Nothing? get() = null
 }

--- a/src/main/kotlin/com/github/derg/transpiler/utils/Numbers.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/utils/Numbers.kt
@@ -1,6 +1,6 @@
 package com.github.derg.transpiler.utils
 
-import java.math.BigInteger
+import java.math.*
 
 operator fun Int.plus(that: BigInteger): BigInteger = this.toBigInteger() + that
 operator fun Long.plus(that: BigInteger): BigInteger = this.toBigInteger() + that

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverInstructions.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.*
  */
 private fun HirFunction.thirCall(): ThirValue
 {
-    val type = ThirTypeCall(null, null, emptyList())
+    val type = ThirTypeFunction(null, null, emptyList())
     
     return ThirCall(null, null, ThirLoad(type, id, emptyList()), emptyList())
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverSymbols.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverSymbols.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Assertions.*
 /**
  * Generates a thir-representation of the struct.
  */
-private fun HirStruct.asThir() = ThirTypeData(
+private fun HirStruct.asThir() = ThirTypeStruct(
     symbolId = id,
     generics = emptyList(),
     mutability = Mutability.IMMUTABLE,

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverSymbols.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverSymbols.kt
@@ -35,7 +35,6 @@ private fun ThirSymbol.toExpected(input: HirSymbol): ThirSymbol = when (this)
 {
     is ThirFunction  -> copy(id = input.id, name = input.name)
     is ThirField     -> copy(id = input.id, name = input.name)
-    is ThirLiteral   -> copy(id = input.id, name = input.name)
     is ThirParameter -> copy(id = input.id, name = input.name)
     is ThirStruct    -> copy(id = input.id, name = input.name)
     is ThirVariable  -> copy(id = input.id, name = input.name)
@@ -183,7 +182,7 @@ class TestResolverSymbol
             
             run(input).valueOrDie()
             
-            assertTrue(input.id in engine.symbols.literals)
+            assertTrue(input.id in engine.symbols.functions)
         }
         
         @Test
@@ -201,7 +200,7 @@ class TestResolverSymbol
         fun `Given instruction, when resolving, then instruction resolved`()
         {
             val input = hirLitOf(instructions = listOf(HirReturn))
-            val symbol = run(input).valueOrDie() as ThirLiteral
+            val symbol = run(input).valueOrDie() as ThirFunction
             
             assertEquals(listOf(ThirReturn), symbol.instructions)
         }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverTypes.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverTypes.kt
@@ -27,7 +27,7 @@ class TestResolverType
         @Test
         fun `Given builtin, when resolving, then correct outcome`()
         {
-            val expected = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            val expected = ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList())
             
             assertSuccess(expected, resolver.resolve(BOOL_TYPE))
         }
@@ -36,7 +36,7 @@ class TestResolverType
         fun `Given user-defined, when resolving, then correct outcome`()
         {
             val struct = hirStructOf().register(scope)
-            val expected = ThirTypeData(struct.id, Mutability.IMMUTABLE, emptyList())
+            val expected = ThirTypeStruct(struct.id, Mutability.IMMUTABLE, emptyList())
             
             assertSuccess(expected, resolver.resolve(hirTypeData(struct)))
         }
@@ -69,8 +69,8 @@ class TestResolverType
         @Test
         fun `Given value, when resolving, then correct outcome`()
         {
-            val value = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
-            val expected = ThirTypeCall(value, null, emptyList())
+            val value = ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            val expected = ThirTypeFunction(value, null, emptyList())
             
             assertSuccess(expected, resolver.resolve(hirTypeCall(value = BOOL_TYPE)))
         }
@@ -78,8 +78,8 @@ class TestResolverType
         @Test
         fun `Given error, when resolving, then correct outcome`()
         {
-            val error = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
-            val expected = ThirTypeCall(null, error, emptyList())
+            val error = ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            val expected = ThirTypeFunction(null, error, emptyList())
             
             assertSuccess(expected, resolver.resolve(hirTypeCall(error = BOOL_TYPE)))
         }
@@ -87,8 +87,8 @@ class TestResolverType
         @Test
         fun `Given parameter, when resolving, then correct outcome`()
         {
-            val param = ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList())
-            val expected = ThirTypeCall(null, null, listOf("" to param))
+            val param = ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList())
+            val expected = ThirTypeFunction(null, null, listOf("" to param))
             
             assertSuccess(expected, resolver.resolve(hirTypeCall(parameters = listOf(BOOL_TYPE))))
         }
@@ -108,7 +108,7 @@ class TestResolverType
         @Test
         fun `Given single, when resolving, then correct outcome`()
         {
-            val inner = listOf(ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()))
+            val inner = listOf(ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList()))
             val expected = ThirTypeUnion(inner)
             
             assertSuccess(expected, resolver.resolve(hirTypeUnion(BOOL_TYPE)))
@@ -118,8 +118,8 @@ class TestResolverType
         fun `Given multiple, when resolving, then correct outcome`()
         {
             val inner = listOf(
-                ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()),
-                ThirTypeData(INT32.id, Mutability.IMMUTABLE, emptyList()),
+                ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList()),
+                ThirTypeStruct(INT32.id, Mutability.IMMUTABLE, emptyList()),
             )
             val expected = ThirTypeUnion(inner)
             
@@ -129,7 +129,7 @@ class TestResolverType
         @Test
         fun `Given nested, when resolving, then correct outcome`()
         {
-            val inner = listOf(ThirTypeData(BOOL.id, Mutability.IMMUTABLE, emptyList()))
+            val inner = listOf(ThirTypeStruct(BOOL.id, Mutability.IMMUTABLE, emptyList()))
             val expected = ThirTypeUnion(listOf(ThirTypeUnion(inner)))
             
             assertSuccess(expected, resolver.resolve(hirTypeUnion(hirTypeUnion(BOOL_TYPE))))

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
@@ -1,17 +1,12 @@
 package com.github.derg.transpiler.phases.resolver
 
 import com.github.derg.transpiler.phases.resolver.ResolveError.*
-import com.github.derg.transpiler.source.INT32_LIT_NAME
-import com.github.derg.transpiler.source.INT64_LIT_NAME
-import com.github.derg.transpiler.source.Mutability
-import com.github.derg.transpiler.source.Symbol
+import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import java.math.BigInteger
+import org.junit.jupiter.api.*
+import java.math.*
 
 /**
  * Simulates what a thir call on [this] function would be given the list of [parameters]. The function is assumed

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
@@ -21,7 +21,7 @@ private fun HirFunction.thirCall(vararg parameters: Any): ThirValue
 {
     val inputs = parameters.map { it.thir }
     val params = this.parameters.zip(inputs).map { it.first.name to it.second.value!! }
-    val type = ThirTypeCall(null, null, params)
+    val type = ThirTypeFunction(null, null, params)
     
     return ThirCall(null, null, ThirLoad(type, id, emptyList()), inputs)
 }
@@ -29,8 +29,8 @@ private fun HirFunction.thirCall(vararg parameters: Any): ThirValue
 private fun HirLiteral.thirCall(parameter: Any): ThirValue
 {
     val input = parameter.thir
-    val output = ThirTypeData(Builtin.INT32.id, Mutability.IMMUTABLE, emptyList())
-    val type = ThirTypeCall(output, null, listOf("" to input.value as ThirTypeData))
+    val output = ThirTypeStruct(Builtin.INT32.id, Mutability.IMMUTABLE, emptyList())
+    val type = ThirTypeFunction(output, null, listOf("" to input.value as ThirTypeStruct))
     
     return ThirCall(output, null, ThirLoad(type, id, emptyList()), listOf(input))
 }
@@ -362,7 +362,7 @@ class TestResolverValue
         @Test
         fun `Given invalid type, when resolving, then correct outcome`()
         {
-            val literal = registerLit("foo", HirTypeCall(null, null, emptyList()))
+            val literal = registerLit("foo", HirTypeFunction(null, null, emptyList()))
             val expected = InvalidLiteralParam(literal.name)
             
             assertFailure(expected, run(HirInteger(BigInteger.ONE, literal.name)))

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
@@ -25,7 +25,7 @@ private fun HirLiteral.thirCall(parameter: Any): ThirValue
 {
     val input = parameter.thir
     val output = ThirTypeStruct(Builtin.INT32.id, Mutability.IMMUTABLE, emptyList())
-    val type = ThirTypeFunction(output, null, listOf("" to input.value as ThirTypeStruct))
+    val type = ThirTypeLiteral(output, input.value as ThirTypeStruct)
     
     return ThirCall(output, null, ThirLoad(type, id, emptyList()), listOf(input))
 }
@@ -352,15 +352,6 @@ class TestResolverValue
             assertSuccess(Long.MAX_VALUE.thir, run(Long.MAX_VALUE.hir))
             assertFailure(InvalidLiteralInteger(INT64_MIN - 1), run(HirInteger(INT64_MIN - 1, INT64_LIT_NAME)))
             assertFailure(InvalidLiteralInteger(INT64_MAX + 1), run(HirInteger(INT64_MAX + 1, INT64_LIT_NAME)))
-        }
-        
-        @Test
-        fun `Given invalid type, when resolving, then correct outcome`()
-        {
-            val literal = registerLit("foo", HirTypeFunction(null, null, emptyList()))
-            val expected = InvalidLiteralParam(literal.name)
-            
-            assertFailure(expected, run(HirInteger(BigInteger.ONE, literal.name)))
         }
         
         @Test

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerValues.kt
@@ -4,8 +4,7 @@ import com.github.derg.transpiler.phases.typechecker.TypeError.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 
 class TestCheckerValues
 {

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -26,7 +26,7 @@ val Any.hir: HirValue
 fun hirTypeData(
     struct: HirStruct = Builtin.INT32,
     mutability: Mutability = Mutability.IMMUTABLE,
-) = HirTypeData(
+) = HirTypeStruct(
     name = struct.name,
     generics = emptyList(),
     mutability = mutability,
@@ -35,7 +35,7 @@ fun hirTypeData(
 fun hirTypeData(
     name: String = UUID.randomUUID().toString(),
     mutability: Mutability = Mutability.IMMUTABLE,
-) = HirTypeData(
+) = HirTypeStruct(
     name = name,
     generics = emptyList(),
     mutability = mutability,
@@ -45,7 +45,7 @@ fun hirTypeCall(
     value: HirType? = null,
     error: HirType? = null,
     parameters: List<HirType> = emptyList(),
-) = HirTypeCall(
+) = HirTypeFunction(
     value = value,
     error = error,
     parameters = parameters.map { "" to it },
@@ -127,7 +127,7 @@ fun hirFunOf(
 ) = HirFunction(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeCall(value, error, params.map { it.name to it.type }),
+    type = HirTypeFunction(value, error, params.map { it.name to it.type }),
     visibility = Visibility.PRIVATE,
     instructions = instructions,
     generics = emptyList(),
@@ -143,7 +143,7 @@ fun hirLitOf(
 ) = HirLiteral(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeCall(value, null, listOf("" to param.type)),
+    type = HirTypeFunction(value, null, listOf("" to param.type)),
     visibility = Visibility.PRIVATE,
     instructions = instructions,
     variables = emptyList(),

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -143,7 +143,7 @@ fun hirLitOf(
 ) = HirLiteral(
     id = UUID.randomUUID(),
     name = name,
-    type = HirTypeFunction(value, null, listOf("" to param.type)),
+    type = HirTypeLiteral(value, param.type as HirTypeStruct),
     visibility = Visibility.PRIVATE,
     instructions = instructions,
     variables = emptyList(),

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -27,7 +27,7 @@ val Any.thir: ThirValue
 fun thirTypeData(
     struct: ThirStruct,
     mutability: Mutability = Mutability.IMMUTABLE,
-) = ThirTypeData(
+) = ThirTypeStruct(
     symbolId = struct.id,
     generics = emptyList(),
     mutability = mutability,
@@ -36,7 +36,7 @@ fun thirTypeData(
 fun thirTypeData(
     symbolId: UUID = UUID.randomUUID(),
     mutability: Mutability = Mutability.IMMUTABLE,
-) = ThirTypeData(
+) = ThirTypeStruct(
     symbolId = symbolId,
     generics = emptyList(),
     mutability = mutability,
@@ -46,7 +46,7 @@ fun thirTypeCall(
     value: ThirType? = null,
     error: ThirType? = null,
     parameters: List<ThirType> = emptyList(),
-) = ThirTypeCall(
+) = ThirTypeFunction(
     value = value,
     error = error,
     parameters = parameters.map { "" to it },
@@ -64,9 +64,9 @@ private fun op(function: HirFunction, value: HirStruct, error: HirStruct?, varar
 {
     val names = if (params.size == 1) mutableMapOf(0 to "rhs") else mutableMapOf(0 to "lhs", 1 to "rhs")
     
-    val valueType = ThirTypeData(value.id, Mutability.IMMUTABLE, emptyList())
-    val errorType = error?.let { ThirTypeData(it.id, Mutability.IMMUTABLE, emptyList()) }
-    val callable = ThirTypeCall(valueType, errorType, params.mapIndexed { i, p -> names[i]!! to p.value!! })
+    val valueType = ThirTypeStruct(value.id, Mutability.IMMUTABLE, emptyList())
+    val errorType = error?.let { ThirTypeStruct(it.id, Mutability.IMMUTABLE, emptyList()) }
+    val callable = ThirTypeFunction(valueType, errorType, params.mapIndexed { i, p -> names[i]!! to p.value!! })
     val instance = ThirLoad(callable, function.id, emptyList())
     
     return ThirCall(valueType, errorType, instance, params.toList())
@@ -160,7 +160,7 @@ fun thirFunOf(
 ) = ThirFunction(
     id = id,
     name = name,
-    type = ThirTypeCall(value, error, params.map { it.name to it.type }),
+    type = ThirTypeFunction(value, error, params.map { it.name to it.type }),
     visibility = Visibility.PRIVATE,
     instructions = emptyList(),
     genericIds = emptySet(),
@@ -176,7 +176,7 @@ fun thirLitOf(
 ) = ThirLiteral(
     id = id,
     name = name,
-    type = ThirTypeCall(value, null, listOf("" to param.type)),
+    type = ThirTypeFunction(value, null, listOf("" to param.type)),
     visibility = Visibility.PRIVATE,
     instructions = emptyList(),
     variableIds = emptySet(),

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -1,9 +1,7 @@
 package com.github.derg.transpiler.source.thir
 
 import com.github.derg.transpiler.source.*
-import com.github.derg.transpiler.source.hir.Builtin
-import com.github.derg.transpiler.source.hir.HirFunction
-import com.github.derg.transpiler.source.hir.HirStruct
+import com.github.derg.transpiler.source.hir.*
 import java.util.*
 
 /////////////////////

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -113,8 +113,12 @@ infix fun Any.thirCatchHandle(that: Any) = ThirCatch(this.thir, that.thir, Captu
 val ThirVariable.thirLoad: ThirValue get() = ThirLoad(type, id, emptyList())
 val ThirParameter.thirLoad: ThirValue get() = ThirLoad(type, id, emptyList())
 val ThirFunction.thirLoad: ThirValue get() = ThirLoad(type, id, emptyList())
-fun ThirFunction.thirCall(vararg parameters: Any) = ThirCall(type.value, type.error, thirLoad, parameters.map { it.thir })
 fun ThirValue.thirCall(value: ThirType? = null, error: ThirType? = null, parameters: List<ThirValue> = emptyList()) = ThirCall(value, error, this, parameters)
+fun ThirFunction.thirCall(vararg parameters: Any): ThirCall = when (val inner = type)
+{
+    is ThirTypeFunction -> ThirCall(inner.value, inner.error, thirLoad, parameters.map { it.thir })
+    is ThirTypeLiteral  -> ThirCall(inner.value, null, thirLoad, parameters.map { it.thir })
+}
 
 ///////////////////////
 // Statement helpers //
@@ -171,14 +175,15 @@ fun thirLitOf(
     name: String = UUID.randomUUID().toString(),
     value: ThirType = thirTypeData(Builtin.INT32.id),
     param: ThirParameter = thirParamOf(),
-) = ThirLiteral(
+) = ThirFunction(
     id = id,
     name = name,
-    type = ThirTypeFunction(value, null, listOf("" to param.type)),
+    type = ThirTypeLiteral(value, param.type as ThirTypeStruct),
     visibility = Visibility.PRIVATE,
     instructions = emptyList(),
+    genericIds = emptySet(),
     variableIds = emptySet(),
-    parameterId = param.id,
+    parameterIds = setOf(param.id),
 )
 
 fun thirParamOf(


### PR DESCRIPTION
This pull request removes the thir literal symbol, and uses the thir function instead. A callable type for literals has been introduced, which will be used by the type system when resolving everything. A literal type is more restricted than functions, but the literals can be implemented as functions to simplify the overall core language.