### PR TITLE
82 improve val/var and mut/ref meaning clarity

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,0 +1,5 @@
+# Concurrency
+
+## Structured concurrency
+
+// TODO: Write me.

--- a/docs/lifetimes.md
+++ b/docs/lifetimes.md
@@ -1,5 +1,0 @@
-# Lifetimes
-
-## Ownership
-
-## Resource management

--- a/docs/lifetimes.md
+++ b/docs/lifetimes.md
@@ -1,0 +1,5 @@
+# Lifetimes
+
+## Ownership
+
+## Resource management

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -16,6 +16,7 @@ Example:
 
 ```derg
 val value = add(1, 2) : 0
+val value = add(1, 2) : compute_default_value(it)
 ```
 
 ### Catch-Raise
@@ -31,6 +32,7 @@ Example:
 
 ```derg
 val value = add(1, 2) !: 0
+val value = add(1, 2) !: apply_error_context(it)
 ```
 
 ### Catch-Return
@@ -47,6 +49,7 @@ Example:
 
 ```derg
 val value = add(1, 2) ?: 0
+val value = add(1, 2) : compute_fallback_value(it)
 ```
 
 ## Logical operators

--- a/docs/program-structure.md
+++ b/docs/program-structure.md
@@ -1,0 +1,113 @@
+# Program Structure
+
+## Packages
+
+A package is a single standalone unit of software. The package is a single folder containing additional folders of
+source code. Each sub-folder in the package corresponds to a new module, and every source code file at the root level of
+the package represents the default module.
+
+Given an empty project, all packages may be declared in the following manner:
+
+```
+root-directory
+  src
+    package-a
+    package-b
+  tests:
+    package-a
+    package-b
+```
+
+The test folder is optional but highly encouraged. All test code is part of the package, but will only be relevant when
+compiling the source code when running tests. The production version of the source code will not contain the test code.
+
+Packages are permitted to depend on each other, although circular dependencies are not permitted. In order to compile a
+package, all dependencies of that package must have been compiled. Dependencies between packages can be implicitly
+resolved based on the modules they contain; by examining the modules imported, we can infer the order in which all
+packages must be compiled.
+
+// TODO: Write about external packages, how can third-party code be included in the application/library?
+
+## Modules
+
+Modules are among the main methods for organizing source code in a structured and coherent manner. Modules can contain
+any number of segments, each of which contribute to the module itself. Any symbol which is defined in any of the
+segments, will be made available to the module as a whole, provided
+the [visibility rules](type-system.md#visibility-modifiers) permit so.
+
+Modules may contain additional submodules. Submodules can be declared by simply creating a sub-folder within the module
+folder. Files placed in the submodules does not contribute to the parent module; a developer who wants to access these
+symbols must explicitly import them, if accessing them from a different module.
+
+The folder structure of modules are declared in the following manner:
+
+```
+package-directory:
+  module-a
+    submodule-1
+    submodule-2
+  module-b
+  module-c
+```
+
+In order to access symbols from a different module, the developer must explicitly import the symbols into the current
+scope. This could be done in the following manner:
+
+```derg
+use module           // Imports all symbols from the module into the current scope.
+use module.submodule // Imports all symbols from the submodule into the current scope.
+use module my_symbol // Imports only `my_symbol` from the module into the current scope.
+```
+
+If multiple symbols with the same name are defined within the module (i.e. overloaded functions), all those symbols are
+imported. In the case of name collisions, symbols may be aliased to avoid issues. Aliasing is possible in the following
+manner:
+
+```derg
+use module my_symbol as alias // Imports `my_symbol` under the name `alias`.
+```
+
+Like packages, modules are not permitted to have circular dependencies. A module cannot be compiled before all other
+modules it depends on have been compiled. Developers should take great care in ensuring that modules are granted a
+single purpose; if two modules strongly relate to each other, the developer should consider merging them into a single
+module instead.
+
+## Segments
+
+Each individual segment within a module represents a single concept or topic within the module. Each segment is
+represented as a single file within the module.
+
+Segments may be declared in the following manner:
+
+```
+module-directory:
+  segment-a.derg
+  segment-b.derg
+```
+
+There are no restrictions on dependencies between segments. Each segment form its own local scope in terms of module
+imports, but otherwise they all live within the same module scope. This means that a symbol defined in one segment, is
+immediately visible in other scopes (provided the symbol's visibility permits that). Note that if a segment imports
+another module, that module's symbols will not be available in another segment.
+
+An example segment may look like the following:
+
+```derg
+use contants
+
+public enum Bracket
+{
+    TOP,
+    MIDDLE,
+    BOTTOM,
+}
+
+public fun compute_tax_rate(bracket: Bracket) -> Float64
+{
+    if bracket == Bracket::TOP
+        return TOP_TAX_RATE
+    if bracket == Bracket::MIDDLE
+        return MIDDLE_TAX_RATE
+    return BOTTOM_TAX_RATE
+}
+```

--- a/docs/resource-management.md
+++ b/docs/resource-management.md
@@ -1,0 +1,391 @@
+# Resource management
+
+Derg does not rely on garbage collection for resource cleanup. Instead, it uses a deterministic approach to resource
+management, similar to RAII (Resource Acquisition Is Initialization) in C++. Instead, all resources, including memory,
+are treated equally and managed by the objects that hold them. Once a resource is assigned to an object, it can be used
+throughout the program. When the object goes out of scope, the resource is automatically released.
+
+This method relieves developers from manually cleaning up memory, file handles, sockets, or any other limited resource.
+The compiler automatically inserts destructors whenever necessary, ensuring everything is eventually freed.
+
+## Lifetimes
+
+Every piece of information in a program has a specific lifetime, determined by the scope in which it appears and how it
+is passed between different scopes. Lifetimes begin when information is created and end when it is destroyed, regardless
+of how it is passed around.
+
+The lifetime of an instance can only be extended by transferring ownership to other parts of the program. Transferring
+ownership means moving the resource, making the original variable invalid; the original variable no longer owns any
+information, therefor it cannot be used. For example:
+
+```derg
+fun my_function()
+{
+    val one = MyResource()
+    val two = one // Ownership of `one` is transferred to `two`.
+    // `one` can no longer be accessed here.
+}
+```
+
+In Derg, information is created through *constructors*, which allocate resources from the machine running the program.
+This information is bound to a specific scope, which determines its lifetime. When the information leaves the scope, it
+is released through *destructors*, which clean up used resources.
+
+Both constructors and destructors can be customized for different types, giving developers full control over resource
+creation and destruction.
+
+### Constructors
+
+Constructors are responsible for creating valid instances of a certain type, ensuring all fields are fully initialized.
+If a constructor cannot create a valid instance, it must raise an error.
+
+Developers can declare new constructors for any type as follows:
+
+```derg
+struct MyType
+{
+    val field_a: Int32
+    val field_b: Int32 = 42
+}
+
+ctor MyType.my_constructor(parameter: Int32)
+{
+    field_a = parameter
+}
+
+val instance = MyType.my_constructor(1337)
+```
+
+A constructor that raises an error can be declared like this:
+
+```derg
+ctor MyType.fallible_constructor(parameter: Int32): MyError
+{
+    if parameter <= 0
+        raise MyError
+    
+    field_a = parameter
+}
+```
+
+*All* fields of the object must be initialized by the constructor. Any field which has a default value, does not have to
+be explicitly initialized, however. A field which has not yet been initialized, cannot be used when executing code in
+the constructor. If a field is not initialized and has no default value, a compile-time error is raised. Once a value
+has been assigned to the field, it may be used as any other variable for expression evaluation, so long as the field
+holds a non-moved value at the end.
+
+Note that all fields must be initialized in the order they appear in the struct itself. A field cannot refer to the
+value of a field declared later within the constructor; for example, `field_a` cannot be assigned the value of
+`field_b`, but `field_b` can be assigned the value of `field_a`.
+
+A default constructor will be defined for all defined structs. This constructor will initialize all fields in the order
+in which they appear in the struct, and allows the developer to override any of the default values. Given the example
+above, the default constructor could be used in the following manner:
+
+```derg
+val instance_a = MyType(field_a = 7, field_b = 10) // Assigning both `field_a` and `field_b`.
+val instance_b = MyType(field_a = 1337)            // Only assigning `field_a`, `field_b` uses the default value.
+```
+
+Constructors are first-class citizens and may be used as parameters. Constructors have a function type, which takes the
+shape `($parameter-list): $error -> move $type-name`. A developer may as such pass constructor functions into other
+functions when needed. Constructors may be passes as parameters in the following manner:
+
+```derg
+fun do_work(constructor: () -> move MyType)
+{
+    val resource = constructor()
+} 
+```
+
+### Destructors
+
+Destructors perform the opposite operation of constructors, defining how a resource should be destroyed once it goes out
+of scope.
+
+Every type must have a destructor in one shape or another, as anything created *must* be destructible. Typically, every
+type can rely on the default destructor, which destroys all fields in the struct in the appropriate order. However, some
+specialized types may want to customize the destructors, allowing the developer to control what happens when the object
+is destroyed. Custom destructors may be declared in the following manner:
+
+```derg
+dtor MyType.my_destructor(parameter: Int32)
+{
+    // Do something.
+}
+```
+
+Within a destructor, *all* fields of the struct must be destroyed, in the opposite order in which they were initialized.
+Any field not explicitly destroyed within a destructor, will be implicitly destroyed, ensuring that the developer does
+not forget anything. Note that if the developer want to destroy any field in a struct manually, the developer must also
+explicitly destroy all the other fields, too.
+
+Note that a destructor is not permitted to raise errors at all. Cleaning up resources is an operation which must succeed
+in all circumstances.
+
+Destructors are first-class citizens and may be used as parameters. Destructors have a function type, which takes the
+shape `move $type-name.(): $error`. A developer may as such pass destructor functions into other functions, and use them
+as if they were normal destructors. For example, a destructor may be used in the following manner:
+
+```derg
+fun do_work(destructor: move MyType.())
+{
+    val resource = MyType()
+    resource.destructor() // The resource is destroyed here.
+} // `resource` is already destroyed, no destroyer is injected here.
+```
+
+## Scopes
+
+In programming languages, a scope is a context in which symbols (such as variables, functions, and types) are defined
+and can be accessed. It determines the visibility and lifetime of these symbols within different parts of a program.
+Scopes help organize code, manage lifetimes of resources, and prevent naming conflicts.
+
+In Derg, scopes function similarly to other programming languages. They define the visibility boundaries of variables
+and resources and control their lifetimes. When an object or variable is created within a scope, it is only accessible
+within that scope and any nested scopes provided the [visiblity rules](type-system.md#visibility-modifiers) are obeyed.
+
+There are two main types of scopes:
+
+- **Global scope**: The global scope is the outermost scope that covers the entire program. All symbols within this
+  scope are accessible from any other part of the program. Symbols are automatically located in the global scope when
+  they are declared at the top-level of any [segment](program-structure.md#segments).
+- **Local scope**: A scope which is limited to a specific block of code, such as a struct, function body, conditional
+  blocks, loops, and so on. Symbols defined within this scope, can only be accessed by name in the same or a nested
+  scope.
+
+Scopes can be nested within other scopes. For example, a local scope inside a function may contain further nested local
+scopes within loops or conditional blocks. Inner scopes can access names from their outer scopes but not vice versa.
+
+Here is an example illustrating the scoping visibility rules:
+
+```derg
+export fun example_function() // `example_function` is in the global scope. It is reachable everywhere by name.
+{
+    val outer_scope_var = 10 // `outer_scope_var` is in the function's local scope.
+
+    if outer_scope_var > 5
+    {
+        val inner_scope_var = 20 // `inner_scope_var` is in the nested local scope (inside the if-statement)
+        // Can access both `inner_scope_var` and `outer_scope_var` here
+    }
+
+    // Can only access `outer_scope_var` here; `inner_scope_var` is out of scope
+}
+```
+
+Scopes are closely tied to the concept of lifetimes in Derg. The lifetime of a resource is determined by the scope in
+which it is defined. When the scope ends, any resources created within it are automatically released. When an object
+goes out of scope, its destructor is called automatically to release any resources it holds. This happens at every point
+where the control flow leaves the scope, such as at the end of a function or when a return statement is executed.
+
+```derg
+fun my_function()
+{
+    val resource = MyResource() // Resource is created and owned by this scope.
+
+    if some_condition
+        return // Resource's destructor is called here.
+
+    // Resource's destructor is called here if `some_condition` is false.
+}
+```
+
+### Ownership
+
+Every piece of information in a source program has exactly one owner, even for temporary r-values. Typically, the owner
+of a resource will be the variable or field which stores the resource, but a function may also own resources according
+to the [parameter passing rules](type-system.md#value-passing).
+
+A resource is always bound to an owner when created and lives until the owner goes out of scope, at which point the
+compiler injects a destructor call to release the resource:
+
+```derg
+fun my_function()
+{
+    val resource = MyResource() // `resource` now owns the resource and will manage it automatically.
+} // `resource` is now out of scope, and the destructor for `MyResource` will be injected here.
+```
+
+A destructor call is injected at every branch where control flow leaves the function body. This ensures that the
+resources are always cleaned up automatically, no matter what function the developer writes.
+
+```derg
+fun my_function(parameter: Bool)
+{
+    val resource = MyResource()
+    if parameter
+        return // `resource` is destroyed here.
+} // `resource` is also destroyed here, since there is no way from the other branch to here.
+```
+
+Passing the ownership of resources is possible, and can be performed in various manners:
+
+```derg
+fun producer() -> move MyResource
+{
+    val resource = MyResource()
+    return resource // Ownership is transferred to the caller.
+}
+
+fun consumer(move resource: Resource) // Ownership is transferred to the function.
+{
+} // Destructor for `resource` runs here as it goes out of scope.
+```
+
+A destructor will not be inserted in situations where the ownership is transferred, however.
+
+When a value is stored within the field of a struct, the ownership model is somewhat more complex, but the same
+principles still hold. The resource stored in the field will only be destroyed once the struct instance goes out of
+scope. See [destructors](#destructors) for further information.
+
+### Borrowing
+
+Merely owning information is not enough to write a program of sufficient complexity. There are many situations where a
+developer needs data to be shared among different tasks, and copying data around yields insufficient performance for
+modern applications. Instead, data may be shared by *borrowing* information, allowing information to be accessed but not
+destroyed.
+
+Borrowing does come with a few considerations, however. If the information which is borrowed, is destroyed while
+borrowed, the program is ill-formed and can result in disastrous outcomes. There are multiple security vulnerabilities
+available, which are caused by reading or writing to deleted data, which is a security issue Derg seeks to rectify. The
+core issue is that a developer cannot be permitted to write a program, such that anything refers to data which has gone
+out of scope.
+
+To accomplish such a goal, Derg ensures that there cannot ever be a reference to anything, which may be destroyed. This
+phrasing does demand a few examples to illustrate the point:
+
+```derg
+fun returning_local_variable() -> borrow MyResource
+{
+    val resource = MyResource()
+
+    return resource // Compiler error, `resource` is no longer valid once the function returns, lifetime is too short.
+}
+
+fun accessing_moved_variable()
+{
+    val old = MyResource()
+    val new = old
+    
+    println(old.data) // Compiler error, `old` does not hold any data here, `new` owns the data instead.
+}
+
+fun accessing_destroyed_variable()
+{
+    val resource = MyResource()
+    resource.custom_destructor()
+    
+    println(resource.data) // Compiler error, `resource` has been destroyed.
+}
+
+fun destroying_borrowed_variable(borrow resource: MyResource)
+{
+    resource.custom_destructor() // Compiler error, cannot destroy non-owned data.
+}
+```
+
+This safety runs much deeper than just examining whether a value is borrowed or not. In Derg, if any information is
+referenced, it is not possible to destroy at all:
+
+```derg
+fun destroying_borrowed_data()
+{
+    val owned_resource = MyResource()
+    ref borrowed_resource = owned_resource
+    
+    owned_resource.custom_destructor() // Compiler error, cannot destroy instance while borrowed by `borrow_resource`.
+}
+
+fun mutating_list_while_borrowed_element()
+{
+    val list = list_of(MyResource(), MyResource())
+    ref borrowed = list.first()
+    
+    list.add(MyResource()) // Compiler error, `list.elements` is potentially destroyed while `borrowed` references an
+                           // element among the elements.
+}
+```
+
+### Memory tagging
+
+// TODO: Heavily in development here!
+
+In order to determine whether information is potentially destroyed when referenced, Derg ensures that every symbol
+holding any information is given a unique tag.
+
+```derg
+struct List[Type]
+{
+    var size: Int32
+    var data: __builtin_ptr[Type]
+}
+
+ctor List()
+{
+    size = 0
+    data = __builtin_allocate_heap_memory[Type](16)
+}
+
+fun myt List.add(move element: Type)
+{
+    size += 1
+    if size == data.capacity
+    {
+        // Perform reallocation here.
+    }
+    data.set(size, element)
+}
+
+struct MyData
+{
+    val resources: List[MyResource]
+}
+```
+
+### Concurrency
+
+Concurrency is critically important in high-performance modern applications, but concurrency can cause major issues in
+regarding memory safety. In traditional languages, concurrency-related bugs are commonly vexing and difficult to fix. In
+Derg, concurrency should be simple to understand and developers should not worry about the safety of the application.
+
+When taking concurrency into view, it is no longer sufficient to simply consider whether a reference to memory is still
+valid or not; multiple heads of execution might add elements to the same list at the same time, resulting in
+inconsistencies to the internal state of the list. For example, two heads of execution might at the same time update a
+list's internal size tracker. Later in the program, an invalid entry might be accessed, resulting in ill-defined
+behavior.
+
+To prevent concurrency-related issues, Derg enforces structured concurrency and prevents multiple heads of execution
+from mutating the same memory. When spawning additional tasks, any information might either be mutated by *a single*
+head of execution, or it can be read by *any number* of heads of execution. Due to structured concurrency, all tasks
+must complete before the surrounding head of execution is permitted to make any progress.
+
+Multiple heads of execution can be spawned using a spawn function:
+
+```derg
+val data = generate_data()
+
+// Spawning three sub-processes which perform read-only operations on `data`.
+run
+{
+    operation_one(data)
+    operation_two(data)
+    operation_three(data)
+}
+// All child processes are complete at this point, Derg guarantees that all heads of execution are merged before control
+// flow is returned to the original caller.
+```
+
+All variables passed into the spawn pool must be read-only. Mutation of shared memory is not permitted:
+
+```derg
+val data = generate_data()
+
+run
+{
+    mutate_data(data) // Compiler error, cannot mutate data in another head of execution. 
+}
+```
+
+Rather than mutating data, sub-processes should instead return their output, which can be concatenated and processed my
+the main process instead.

--- a/docs/resource-management.md
+++ b/docs/resource-management.md
@@ -343,6 +343,21 @@ struct MyData
 }
 ```
 
+### Dynamic dispatch
+
+// TODO: Write me. This is all notes and raw brain dump at the moment.
+
+The type system cannot prove or disprove that the code is memory safe when dynamic dispatching is introduced. As such,
+we need some way to opt-out of the compiler saying no when we *know* the code is safe but cannot prove it. Examples of
+safe but unprovable code can look like the following:
+
+```derg
+trait MyTrait
+{
+    fun do_work()
+}
+```
+
 ### Concurrency
 
 Concurrency is critically important in high-performance modern applications, but concurrency can cause major issues in

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -63,3 +63,11 @@ do_work() // Legal, function returns no value, nor does it raise any error.
 make_it() // Not legal, expression has a value type associated with it.
 9001      // Not legal, expression has a value type associated with it. 
 ```
+
+### Raise
+
+// TODO: Write me.
+
+### Return
+
+// TODO: Write me.

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -1,0 +1,162 @@
+# Type System
+
+The type system of a programming language is perhaps one of the strongest advantages for writing large pieces of
+software. With a strong type system, a developer can rest assured that the compiler can detect and report a large number
+of erroneous programs, without the developer needing to run the program in the first place. The compiler can deduce that
+a function cannot be called with some values, that certain values are unused, errors are not handled, and much more.
+
+In Derg, the type system allows the developer to express their intent clearly and concisely. All values are associated
+with a type, which determines how the value can and cannot be used. The shape of the data, visibility, mutability,
+parameter passing rules, and so on influences the possible ways values may be passed around.
+
+## Visibility modifiers
+
+The visibility of a symbol influences where the symbol may be used in source code. The visibility of a symbol details
+the effective scope which can access it by name - a scope which is outside the visibility range specified by the
+developer cannot access said symbol by name.
+
+Visibility modifiers come in four different levels:
+
+- **EXPORTED**: The symbol is accessible to everything outside the current package. It may be used in any part of the
+  source code, including third-party code. Any code which should be shared between different packages, must be declared
+  as exported - this is the only visibility level which allows third-party usage; libraries should declare all symbols
+  forming the actual interface as `exported`.
+- **PUBLIC**: The symbol is accessible to all modules within the current package. This visibility layer allows all
+  modules within the package to access the symbol by name. The public visibility should be used for symbols which are
+  used throughout the module, but should not be exposed to the consumers of the code. For an application package,
+  symbols such as loggers, database connections, and similar might be declared `public`.
+- **PROTECTED**: The symbol is accessible to everything within the same module as the object was declared in. The object
+  will not be visible to anything outside the current module. This is useful for implementing behavior for the module,
+  but should not form part of the module's interface. Such symbols are declared `protected`.
+- **PRIVATE**: The symbol is only accessible by name to the segment it is declared in. This is useful to hide
+  implementation details which are not relevant to other parts of the software. Examples include simple helper functions
+  and utilities used to implement the actual behavior (i.e. transforming data from one struct to another) or other
+  low-level handling. Such symbols are typically declared `private`.
+
+Example of different visibilities:
+
+```derg
+export  val CONSTANT_A = 1 // Accessible everywhere.
+public  val CONSTANT_B = 2 // Accessible only in the same package.
+protect val CONSTANT_C = 3 // Accessible only in the same module.
+private val CONSTANT_D = 4 // Accessible only in the same segment.
+```
+
+## Mutability modifiers
+
+In software, state is common and often everywhere. A program in which state changes frequently is typically harder to
+reason around, but if no state is permitted to change the programming language quickly becomes less ergonomic. In Derg,
+mutability is a key concept; the developer is granted powerful tools to express the intentions in a clean and
+comprehensible manner.
+
+Mutability in Derg revolves around two key concepts, assignments and mutations. Assignments refer to changing which
+value is bound to a specific variable at any given time, whereas mutation refers to mutating a value *through* a
+binding. Depending on how a variable is declared, and the type of the variable, assignment and/or mutation may be
+prohibited.
+
+### Bindings
+
+When a developer declares a variable or struct field, the symbol must be declared as final or non-final. Any variable
+which is declared final, cannot be re-assigned. If the variable is declared within a function body, then every time the
+function is invoked a different instance of that variable may be granted a different value.
+
+A non-final variable can be altered as many times as needed, however. Typically, a running sum when computing the sum of
+all numbers in a list would be non-final. The sum would continuously be assigned the new current total with each
+iteration. However, allowing variables to be assigned different values can quickly make a program harder to follow. As
+such, non-final variables should be used sparingly.
+
+A final variable is declared using `val`, whereas a non-final one is declared with `var`. Examples of such variables can
+be seen here:
+
+```derg
+struct MyData
+{
+    val name: String // Final, cannot be re-assigned once given a value.
+    var age: Int32   // Non-final, can be re-assigned at any time.
+} 
+```
+
+Note that final and non-final bindings applies to the symbol itself, not the value contained within the variable. A
+variable can be final or non-final, independent of what the actual mutability of the value is.
+
+### Mutation
+
+Values are different from variables and fields, in the sense they do not point to a specific location in memory, but
+rather represent some data. This data can be considered logically constant, or be permitted to be mutated.
+
+Data which is logically constant, cannot be modified in any way through the binding pointing to it. For example, a list
+which is declared constant, cannot be appended to in the current context - it may be changed elsewhere in the program,
+but in this context it is effectively a read-only value. Mutable data, however, can be modified as much as the developer
+likes. A mutable list can be appended to, elements can be removed, or even updated if the element type permits such.
+
+The mutation of values has far-reaching consequences; the developer is able to express deeply mutable structures, or
+shallowly mutable structures on-demand. For example, a developer will be able to express that a function can take in a
+mutable list, but the elements within the list cannot be mutated. Or alternatively, the developer expresses that the
+list *cannot* be mutated, but the elements within it *can* be.
+
+Mutation applies to the type of the value itself, and may be declared in the following manner:
+
+```derg
+struct MyData
+{
+    val my_const: List[Int]   // A list which cannot be mutated, the contents of the list will never change.
+    val my_mut: mut List[Int] // A list which can be modified, its contents is permitted to change.
+} 
+```
+
+Note that there is a subtle but important difference between mutability of values, versus assigning new values to a
+binding. By reassigning a variable, the old value is destroyed before moving the new value in place. This has various
+performance impacts; for large resources, creating the new value may be a costly operation. Mutating the data in-place
+is typically a more efficient solution.
+
+## Value passing
+
+Unlike most other programming languages, Derg does not focus on *how* a parameter is passed into or out of a function,
+but rather on the *why*. The developer will not have to worry about the details of whether a value is considered an
+l-value, r-value, pointer, or similar. Instead, developers can focus on the intentions of the program, by explicitly
+stating what the purpose of the parameter is instead.
+
+Values may be passed into and out of functions in one of multiple manners:
+
+- **BORROW**: The most common way to pass values around is as a borrowed value. If the developer needs to make changes
+  to a value as a side effect within a function, or provide access to a value in a struct, the parameter or return value
+  can be declared as `borrow`. In this case, the binding is an alias to the value passed into or out of the function.
+  The binding itself cannot be assigned a new value, but if the type of the parameter permits so, it may be mutated as a
+  side effect.
+- **MOVE**: The developer can transfer ownership of a value into or out of a function, by declaring a parameter
+  as `move`. When doing so, the value passed into the function can no longer be used on the outside, as it does no
+  longer exist there. The function which accepted the value, will from now on be responsible for managing its lifetime.
+- **COPY**: If the developer does not want to pass ownership, nor deal with lifetime rules, they may declare the value
+  as `copy` instead. Any type which is copyable, can be passed in this manner; for types which are not trivially
+  copyable, the developer may have to write the functionality for copying the type first.
+
+When a value is passed as `borrow`, the developer will have to take the [lifetime](lifetimes.md#lifetimes) of the value
+into consideration. A value cannot outlive the scope it is declared in, nor can the memory the value resides in be
+invalidated in any way, shape, or form. Note that values owned by a scope cannot be borrowed to a scope that outlives
+the original scope; this means that functions cannot return borrows to local variables.
+
+A value which is moved, cannot be accessed in the previous scope. For example, a value passed into a function by `move`,
+is now inaccessible in the function it was originally declared in. Any access to the value through its previous binding
+is a compile-time error. As [ownership](lifetimes.md#ownership) is transferred to another scope, once the value goes out
+of the new scope it will be destroyed as usual.
+
+Note that passing values by copy, does not mean a bitwise identical copy is passed. All types which are copyable, must
+define a copy function, detailing how the data can be copied. The types themselves are responsible for defining what
+constitutes a valid copy. Typically, a copy means a deep copy, where nested data is copied as well, rather than just the
+reference to the nested data.
+
+Values may be passed into functions in the following manners:
+
+```derg
+fun my_function(borrow input: Int32) // Passes the value as a borrowed value. 
+fun my_function(move input: Int32)   // Passes overship of the value into the function.
+fun my_function(copy input: Int32)   // Passes a copy of the value into the function.
+```
+
+Values may be returned from functions in the following manners:
+
+```derg
+fun my_function() -> borrow Int32 // Returns a borrowed value from the function.
+fun my_function() -> move Int32   // Returns a value together with its ownership from the function.
+fun my_function() -> copy Int32   // Returns a copy of some inner value from the function.
+```

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -130,15 +130,15 @@ Values may be passed into and out of functions in one of multiple manners:
   as `copy` instead. Any type which is copyable, can be passed in this manner; for types which are not trivially
   copyable, the developer may have to write the functionality for copying the type first.
 
-When a value is passed as `borrow`, the developer will have to take the [lifetime](lifetimes.md#lifetimes) of the value
-into consideration. A value cannot outlive the scope it is declared in, nor can the memory the value resides in be
-invalidated in any way, shape, or form. Note that values owned by a scope cannot be borrowed to a scope that outlives
-the original scope; this means that functions cannot return borrows to local variables.
+When a value is passed as `borrow`, the developer will have to take the [lifetime](resource-management.md#lifetimes) of
+the value into consideration. A value cannot outlive the scope it is declared in, nor can the memory the value resides
+in be invalidated in any way, shape, or form. Note that values owned by a scope cannot be borrowed to a scope that
+outlives the original scope; this means that functions cannot return borrows to local variables.
 
 A value which is moved, cannot be accessed in the previous scope. For example, a value passed into a function by `move`,
 is now inaccessible in the function it was originally declared in. Any access to the value through its previous binding
-is a compile-time error. As [ownership](lifetimes.md#ownership) is transferred to another scope, once the value goes out
-of the new scope it will be destroyed as usual.
+is a compile-time error. As [ownership](resource-management.md#ownership) is transferred to another scope, once the
+value goes out of the new scope it will be destroyed as usual.
 
 Note that passing values by copy, does not mean a bitwise identical copy is passed. All types which are copyable, must
 define a copy function, detailing how the data can be copied. The types themselves are responsible for defining what

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typer/TypeTable.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typer/TypeTable.kt
@@ -1,0 +1,16 @@
+package com.github.derg.transpiler.phases.typer
+
+import com.github.derg.transpiler.source.thir.*
+import java.util.*
+
+/**
+ * The type table contains information regarding the various objects which have had their types resolved. When an
+ * object's type is resolved, it can be used for all type resolution purposes. For example, the actual callable to
+ * invoke can be determined by the parameters, once the types are known.
+ */
+class TypeTable
+{
+    val bindings = mutableMapOf<UUID, ThirType>()
+    val functions = mutableMapOf<UUID, ThirTypeFunction>()
+    val literals = mutableMapOf<UUID, ThirTypeLiteral>()
+}


### PR DESCRIPTION
Closes #82.

This pull request introduces some documentation describing the ideas of how to handle value passing and mutation in a more coherent and clear manner, than the issue text describes. Or, it tries to - further refinement over time is needed, but this forms the basis for future discussion.

For example, future work includes deciding upon some default value passing (i.e. `borrow`), default visibility, and so on.