### PR TITLE
Introduce ast program structure

### DIFF
--- a/docs/program-structure.md
+++ b/docs/program-structure.md
@@ -9,13 +9,17 @@ the package represents the default module.
 Given an empty project, all packages may be declared in the following manner:
 
 ```
-root-directory
-  src
-    package-a
-    package-b
-  tests:
-    package-a
-    package-b
+root-directory:
+  src:
+    bin:
+      application-a.derg
+      application-b.derg
+    lib:
+      package-a
+      package-b
+    tests:
+      package-a
+      package-b
 ```
 
 The test folder is optional but highly encouraged. All test code is part of the package, but will only be relevant when
@@ -35,19 +39,24 @@ any number of segments, each of which contribute to the module itself. Any symbo
 segments, will be made available to the module as a whole, provided
 the [visibility rules](type-system.md#visibility-modifiers) permit so.
 
+Each segment is represented as a regular source code file. While the name of the module is meaningful, the name of each
+segment file is not. The name of segment files may be used to hint to the contents of said file. Note that a module does
+not need to contain any source code files, in which case the module does nothing and holds no content.
+
 Modules may contain additional submodules. Submodules can be declared by simply creating a sub-folder within the module
-folder. Files placed in the submodules does not contribute to the parent module; a developer who wants to access these
-symbols must explicitly import them, if accessing them from a different module.
+folder. Files placed in the submodules does not contribute to the parent module; they are only applicable to the nearest
+defined module. This means that anything declared in a submodule, does not exist in the parent module - these modules
+are fully unrelated to each other.
 
 The folder structure of modules are declared in the following manner:
 
 ```
 package-directory:
-  module-a
+  module-a:
     submodule-1
     submodule-2
-  module-b
-  module-c
+  module-b:
+  module-c:
 ```
 
 In order to access symbols from a different module, the developer must explicitly import the symbols into the current
@@ -72,12 +81,22 @@ modules it depends on have been compiled. Developers should take great care in e
 single purpose; if two modules strongly relate to each other, the developer should consider merging them into a single
 module instead.
 
-## Segments
+## Source files
 
-Each individual segment within a module represents a single concept or topic within the module. Each segment is
-represented as a single file within the module.
+Source files are where the actual code written by a developer reside. The source code files come in two different
+flavors, application source code and library source code. Application source code lives in the `bin` folder, whereas the
+library source code lives in the `lib` folder.
 
-Segments may be declared in the following manner:
+Additionally, application source files behave slightly differently from ordinary library source code files. Most
+notably, an application source code file must contain the `main` function, which is the application's entry point. All
+code present within the application source file also resides in an unnamed module, meaning the code can never be
+imported.
+
+Each individual source code file within a module usually represents a single concept or topic within the module. The
+developer may use multiple source code files to fragment a module into small pieces, making the overall codebase easier
+to comprehend.
+
+Source files may be declared in the following manner:
 
 ```
 module-directory:
@@ -85,12 +104,23 @@ module-directory:
   segment-b.derg
 ```
 
-There are no restrictions on dependencies between segments. Each segment form its own local scope in terms of module
-imports, but otherwise they all live within the same module scope. This means that a symbol defined in one segment, is
-immediately visible in other scopes (provided the symbol's visibility permits that). Note that if a segment imports
-another module, that module's symbols will not be available in another segment.
+There are no restrictions on dependencies between source files. Each file form its own local scope in terms of module
+imports, but otherwise they all live within the same module scope. This means that a symbol defined in one file, is
+immediately visible in other scopes (provided the symbol's visibility permits that). Note that if a source file imports
+a module, that module's symbols will not be visible to any source file which did not explicitly import it.
 
-An example segment may look like the following:
+An example application source file may look like the following:
+
+```derg
+use std.io
+
+fun main()
+{
+    print("Hello World!")
+}
+```
+
+An example library source file may look like the following:
 
 ```derg
 use contants

--- a/src/main/kotlin/com/github/derg/transpiler/Main.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/Main.kt
@@ -4,6 +4,7 @@ import com.github.derg.transpiler.phases.converter.*
 import com.github.derg.transpiler.phases.parser.*
 import com.github.derg.transpiler.phases.resolver.*
 import com.github.derg.transpiler.phases.typechecker.*
+import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.utils.*
 
 private const val SOURCE = """
@@ -18,10 +19,12 @@ private const val SOURCE = """
     }
 """
 
+private fun AstSegment.toProgram() = AstProgram(applications = listOf(this), packages = emptyList())
+
 fun main(args: Array<String>)
 {
-    val ast = parse(SOURCE).valueOrDie()
-    val hir = convert(listOf(ast))
+    val ast = parse(SOURCE).valueOrDie().toProgram()
+    val hir = convert(ast)
     val thir = resolve(hir).valueOrDie()
     
     check(thir).valueOrDie()

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -5,19 +5,12 @@ import com.github.derg.transpiler.source.hir.*
 import java.util.*
 
 /**
- * Converts the provided AST [segments] into a HIR package. The input segments are all used to form the single package.
+ * Converts the provided AST [program] into a HIR program. The input segments are all used to form the single package.
  * Note that segments from another package, must be separately converted into the HIR structure.
  */
-fun convert(segments: List<AstSegment>) = HirPackage(
-    id = UUID.randomUUID(),
-    name = "TODO - package name",
-    modules = segments.groupBy { it.module ?: "TODO - module name" }.map { module(it.key, it.value) }
-)
-
-private fun module(name: String, segments: List<AstSegment>) = HirModule(
-    id = UUID.randomUUID(),
-    name = name,
-    segments = segments.map { it.toHir() },
+fun convert(program: AstProgram) = HirProgram(
+    applications = program.applications.map { it.toHir() },
+    packages = program.packages.map { it.toHir() },
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -65,12 +58,30 @@ internal fun AstFunction.toHir() = HirFunction(
 /**
  *
  */
+internal fun AstModule.toHir() = HirModule(
+    id = UUID.randomUUID(),
+    name = name,
+    segments = segments.map { it.toHir() },
+)
+
+/**
+ *
+ */
 internal fun AstParameter.toHir() = HirParameter(
     id = UUID.randomUUID(),
     name = name,
     type = type.toHir(),
     value = value?.toHir(),
     passability = passability,
+)
+
+/**
+ *
+ */
+internal fun AstPackage.toHir() = HirPackage(
+    id = UUID.randomUUID(),
+    name = name,
+    modules = modules.map { it.toHir() },
 )
 
 /**
@@ -89,8 +100,6 @@ internal fun AstProperty.toHir() = HirField(
  *
  */
 internal fun AstSegment.toHir() = HirSegment(
-    id = UUID.randomUUID(),
-    name = "TODO - segment name",
     imports = imports.toSet(),
     structs = definitions.filterIsInstance<AstStruct>().map { it.toHir() },
     concepts = emptyList(),

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
@@ -196,16 +196,13 @@ private fun scopeOutcomeOf(values: Parsers): List<AstInstruction>
 fun segmentParserOf(): Parser<AstSegment> =
     ParserPattern(::segmentPatternOf, ::segmentOutcomeOf)
 
-// TODO: Use statements should allow modules to be imported into namespaces
 private fun segmentPatternOf() = ParserSequence(
-    "module" to ParserOptional(nameParserOf(Symbol.MODULE)),
-    "imports" to ParserRepeating(nameParserOf(Symbol.USE)),
+    "imports" to ParserRepeating(nameParserOf(Symbol.USE)), // TODO: Use statements should allow modules to be aliased
     "definitions" to ParserRepeating(definitionParserOf()),
     "end" to ParserEnd,
 )
 
 private fun segmentOutcomeOf(values: Parsers) = AstSegment(
-    module = values["module"],
     imports = values["imports"],
     definitions = values["definitions"],
 )

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
@@ -32,10 +32,7 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
         is HirGeneric   -> TODO()
         is HirLiteral   -> handle(node)
         is HirMethod    -> TODO()
-        is HirModule    -> TODO()
-        is HirPackage   -> TODO()
         is HirParameter -> handle(node)
-        is HirSegment   -> TODO()
         is HirStruct    -> handle(node)
         is HirVariable  -> handle(node)
     }

--- a/src/main/kotlin/com/github/derg/transpiler/source/Enums.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/Enums.kt
@@ -176,7 +176,6 @@ enum class Symbol(val symbol: String)
     FUN("fun"),
     IF("if"),
     IN("in"),
-    MODULE("module"),
     MUTABLE("mut"),
     MOVE("move"),
     OUT("out"),

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Metadata.kt
@@ -21,18 +21,3 @@ data class AstArgument(
     val name: String?,
     val expression: AstValue,
 )
-
-/**
- * Every source code file is parsed into a single segment, in which the total collection of segments with the same
- * module name form a single module. The segment forms the most basic building block when structuring code, and is the
- * component which allows code fragmentation to take place.
- *
- * @param module The name of the module this segment is part of.
- * @param imports The modules which are to be imported into this segment.
- * @param definitions All components which are injected into the module by this segment.
- */
-data class AstSegment(
-    val module: String?,
-    val imports: List<String>,
-    val definitions: List<AstSymbol>,
-)

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Program.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Program.kt
@@ -1,0 +1,52 @@
+package com.github.derg.transpiler.source.ast
+
+/**
+ * The source code of the entire program represented as a single abstract syntax tree.
+ *
+ * @param applications The collection of applications which should be built concurrently.
+ * @param packages The collection of packages which together makes up the entire program.
+ */
+data class AstProgram(
+    val applications: List<AstSegment>,
+    val packages: List<AstPackage>,
+)
+
+/**
+ * The core data structure holding the shape of the entire package. The abstract syntax tree contains every syntactic
+ * element of the source code, stripped of all non-semantic information. Comments and whitespace has been fully stripped
+ * from the source code.
+ *
+ * @param name The name of the package.
+ * @param modules The collection of modules which makes up the package.
+ */
+data class AstPackage(
+    val name: String,
+    val modules: List<AstModule>,
+)
+
+/**
+ * Any module may contain an arbitrary number of nested elements. Modules are what forms the basis of the application,
+ * enabling it to be modularized.
+ *
+ * @param name The name of the module.
+ * @param modules The submodules residing within this module.
+ * @param segments The source code files which reside within this module.
+ */
+data class AstModule(
+    val name: String,
+    val modules: List<AstModule>,
+    val segments: List<AstSegment>,
+)
+
+/**
+ * Every source code file is parsed into a single segment, in which the total collection of segments with the same
+ * module name form a single module. The segment forms the most basic building block when structuring code, and is the
+ * component which allows code fragmentation to take place.
+ *
+ * @param imports The modules which are to be imported into this segment.
+ * @param definitions All components which are injected into the module by this segment.
+ */
+data class AstSegment(
+    val imports: List<String>,
+    val definitions: List<AstSymbol>,
+)

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Program.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Program.kt
@@ -1,0 +1,41 @@
+package com.github.derg.transpiler.source.hir
+
+import java.util.*
+
+/**
+ * Programs contain all information needed to build up all applications and dependencies from source code.
+ */
+data class HirProgram(
+    val applications: List<HirSegment>,
+    val packages: List<HirPackage>,
+)
+
+/**
+ * Packages represents an entire program or library, containing all relevant code and constructs to make it work.
+ */
+data class HirPackage(
+    val id: UUID,
+    val name: String,
+    val modules: List<HirModule>,
+)
+
+/**
+ * Modules are high-level constructs which contains any number of identifiable objects. Modules may import any number of
+ * other modules, forming the dependency graph between them.
+ */
+data class HirModule(
+    val id: UUID,
+    val name: String,
+    val segments: List<HirSegment>,
+)
+
+/**
+ * A segment represents a single source file of code.
+ */
+data class HirSegment(
+    val imports: Set<String>,
+    val structs: List<HirStruct>,
+    val concepts: List<HirConcept>,
+    val constants: List<HirConstant>,
+    val functions: List<HirFunction>,
+)

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Symbols.kt
@@ -13,48 +13,6 @@ sealed interface HirSymbol
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Structures
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/**
- * Packages represents an entire program or library, containing all relevant code and constructs to make it work.
- */
-data class HirPackage(
-    override val id: UUID,
-    override val name: String,
-    
-    // Symbols present within the object
-    val modules: List<HirModule>,
-) : HirSymbol
-
-/**
- * Modules are high-level constructs which contains any number of identifiable objects. Modules may import any number of
- * other modules, forming the dependency graph between them.
- */
-data class HirModule(
-    override val id: UUID,
-    override val name: String,
-    
-    // Symbols present within the object
-    val segments: List<HirSegment>,
-) : HirSymbol
-
-/**
- * A segment represents a single source file of code.
- */
-data class HirSegment(
-    override val id: UUID,
-    override val name: String,
-    val imports: Set<String>,
-    
-    // Symbols present within the object
-    val structs: List<HirStruct>,
-    val concepts: List<HirConcept>,
-    val constants: List<HirConstant>,
-    val functions: List<HirFunction>,
-) : HirSymbol
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Types
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParser.kt
@@ -11,16 +11,24 @@ class TestParser
     @Test
     fun `Given empty segment, when parsing, then correctly parsed`()
     {
-        val expected = astSegmentOf(module = null, imports = emptyList(), statements = emptyList())
+        val expected = astSegmentOf(imports = emptyList(), statements = emptyList())
         
         assertSuccess(expected, parse(""))
     }
     
     @Test
-    fun `Given populated segment, when parsing, then correctly parsed`()
+    fun `Given import, when parsing, then correctly parsed`()
+    {
+        val expected = astSegmentOf(imports = listOf("foo"))
+        
+        assertSuccess(expected, parse("use foo"))
+    }
+    
+    @Test
+    fun `Given statement, when parsing, then correctly parsed`()
     {
         val variable = astConstOf("foo", type = "Int", value = 42)
-        val expected = astSegmentOf(module = null, imports = emptyList(), statements = listOf(variable))
+        val expected = astSegmentOf(statements = listOf(variable))
         
         assertSuccess(expected, parse("val foo: Int = 42"))
     }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserMetadata.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserMetadata.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.parser
 
+import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.lexeme.*
 import org.junit.jupiter.api.*
@@ -42,7 +43,6 @@ class TestParserSegment
     fun `Given valid segment, when parsing, then correctly parsed`()
     {
         tester.parse("").isDone().isValue(astSegmentOf())
-        tester.parse("module foo").isWip(2).isDone().isValue(astSegmentOf(module = "foo"))
         tester.parse("use foo").isWip(2).isDone().isValue(astSegmentOf(imports = listOf("foo")))
         tester.parse("val foo: Int = 0").isWip(6).isDone().isValue(astSegmentOf(statements = listOf(astConstOf("foo", type = "Int"))))
         tester.parse("fun foo() {}").isWip(6).isDone().isValue(astSegmentOf(statements = listOf(astFunOf("foo"))))
@@ -51,7 +51,7 @@ class TestParserSegment
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
-        tester.parse("module").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("in").isBad { ParseError.UnexpectedToken(Keyword(Symbol.IN)) }
         tester.parse("use").isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -94,11 +94,9 @@ fun astConstOf(
  * Generates segment definition from the provided input parameters.
  */
 fun astSegmentOf(
-    module: String? = null,
     imports: List<String> = emptyList(),
     statements: List<AstSymbol> = emptyList(),
 ) = AstSegment(
-    module = module,
     imports = imports,
     definitions = statements,
 )


### PR DESCRIPTION
A Derg program is expected to be distributed in a specific manner on disk, but the AST did not reflect this structure in a good manner. This pull request attempts to align the AST with the plans for the language slightly better. We can build on the idea of representing the entire source code as a program during type resolution, by providing a natural home for information which is related to each stage.