### PR TITLE
Additional AST node features

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -137,7 +137,7 @@ internal fun AstVariable.toHir() = HirVariable(
 internal fun AstValue.toHir(): HirValue = when (this)
 {
     is AstCall         -> HirCall(HirLoad(name, emptyList()), valArgs.map { it.name to it.expression.toHir() })
-    is AstRead         -> HirLoad(name, emptyList())
+    is AstLoad         -> HirLoad(name, temArgs.map { it.name to it.expression.toHir() })
     is AstBool         -> HirBool(value)
     is AstInteger      -> HirInteger(value, literal)
     is AstDecimal      -> HirDecimal(value, literal)

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -136,8 +136,8 @@ internal fun AstVariable.toHir() = HirVariable(
  */
 internal fun AstValue.toHir(): HirValue = when (this)
 {
-    is AstCall         -> HirCall(HirLoad(name, emptyList()), valArgs.map { it.name to it.expression.toHir() })
-    is AstLoad         -> HirLoad(name, temArgs.map { it.name to it.expression.toHir() })
+    is AstCall         -> HirCall(instance.toHir(), parameters.map { it.name to it.expression.toHir() })
+    is AstLoad         -> HirLoad(name, parameters.map { it.name to it.expression.toHir() })
     is AstBool         -> HirBool(value)
     is AstInteger      -> HirInteger(value, literal)
     is AstDecimal      -> HirDecimal(value, literal)

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -1,6 +1,5 @@
 package com.github.derg.transpiler.phases.converter
 
-import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.hir.*
 import java.util.*
@@ -171,11 +170,16 @@ internal fun AstValue.toHir(): HirValue = when (this)
  */
 internal fun AstInstruction.toHir(): HirInstruction = when (this)
 {
-    is AstAssign      -> HirAssign(HirLoad(name, emptyList()), expression.toHir())
-    is AstBranch      -> HirBranch(predicate.toHir(), success.map { it.toHir() }, failure.map { it.toHir() })
-    is AstEvaluate    -> HirEvaluate(expression.toHir())
-    is AstReturn      -> HirReturn
-    is AstReturnError -> HirReturnError(expression.toHir())
-    is AstReturnValue -> HirReturnValue(expression.toHir())
-    is AstVariable    -> HirAssign(HirLoad(name, emptyList()), value.toHir())
+    is AstAssign         -> HirAssign(HirLoad(name, emptyList()), expression.toHir())
+    is AstAssignDivide   -> HirAssignDivide(HirLoad(name, emptyList()), expression.toHir())
+    is AstAssignSubtract -> HirAssignSubtract(HirLoad(name, emptyList()), expression.toHir())
+    is AstAssignModulo   -> HirAssignModulo(HirLoad(name, emptyList()), expression.toHir())
+    is AstAssignMultiply -> HirAssignMultiply(HirLoad(name, emptyList()), expression.toHir())
+    is AstAssignAdd      -> HirAssignAdd(HirLoad(name, emptyList()), expression.toHir())
+    is AstBranch         -> HirBranch(predicate.toHir(), success.map { it.toHir() }, failure.map { it.toHir() })
+    is AstEvaluate       -> HirEvaluate(expression.toHir())
+    is AstReturn         -> HirReturn
+    is AstReturnError    -> HirReturnError(expression.toHir())
+    is AstReturnValue    -> HirReturnValue(expression.toHir())
+    is AstVariable       -> HirAssign(HirLoad(name, emptyList()), value.toHir())
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserExpressions.kt
@@ -153,7 +153,7 @@ private fun callPatternOf() = ParserSequence(
 )
 
 private fun callOutcomeOf(outcome: Parsers): AstValue =
-    AstCall(outcome["name"], emptyList(), outcome["params"])
+    AstCall(AstLoad(outcome["name"], emptyList()), outcome["params"])
 
 /**
  * Parses an expression from in-between parenthesis from the token stream.

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -102,7 +102,7 @@ private fun returnOutcomeOf(values: Parsers): AstInstruction
 {
     val expression = values.get<AstValue>("expression")
     // TODO: The magic string `_` should not be used. Use the type-information of the function to remove it
-    return if (expression == AstRead("_")) AstReturn else AstReturnValue(expression)
+    return if (expression == AstLoad("_", emptyList())) AstReturn else AstReturnValue(expression)
 }
 
 /**
@@ -111,4 +111,4 @@ private fun returnOutcomeOf(values: Parsers): AstInstruction
  */
 // TODO: Not a correct implementation of the parser - must also function with error handling
 private fun invokeParserOf(): Parser<AstInstruction> =
-    ParserPattern(::functionCallParserOf) { AstEvaluate(it) }
+    ParserPattern(::callParserOf) { AstEvaluate(it) }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserStatements.kt
@@ -9,11 +9,11 @@ import com.github.derg.transpiler.source.ast.*
 private fun merge(name: String, operator: Symbol, rhs: AstValue): AstInstruction = when (operator)
 {
     Symbol.ASSIGN          -> AstAssign(name, rhs)
-    Symbol.ASSIGN_PLUS     -> AstAssign(name, AstAdd(AstRead(name), rhs))
-    Symbol.ASSIGN_MINUS    -> AstAssign(name, AstSubtract(AstRead(name), rhs))
-    Symbol.ASSIGN_MULTIPLY -> AstAssign(name, AstMultiply(AstRead(name), rhs))
-    Symbol.ASSIGN_MODULO   -> AstAssign(name, AstModulo(AstRead(name), rhs))
-    Symbol.ASSIGN_DIVIDE   -> AstAssign(name, AstDivide(AstRead(name), rhs))
+    Symbol.ASSIGN_PLUS     -> AstAssignAdd(name, rhs)
+    Symbol.ASSIGN_MINUS    -> AstAssignSubtract(name, rhs)
+    Symbol.ASSIGN_MULTIPLY -> AstAssignMultiply(name, rhs)
+    Symbol.ASSIGN_MODULO   -> AstAssignModulo(name, rhs)
+    Symbol.ASSIGN_DIVIDE   -> AstAssignDivide(name, rhs)
     else                   -> throw IllegalStateException("Illegal operator $operator when parsing assignment")
 }
 

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
@@ -23,12 +23,17 @@ internal class ResolverInstruction(private val types: TypeTable, private val sco
      */
     fun resolve(node: HirInstruction): Result<ThirInstruction, ResolveError> = when (node)
     {
-        is HirAssign      -> handle(node)
-        is HirBranch      -> handle(node)
-        is HirEvaluate    -> handle(node)
-        is HirReturn      -> ThirReturn.toSuccess()
-        is HirReturnError -> values.resolve(node.expression).mapValue { ThirReturnError(it) }
-        is HirReturnValue -> values.resolve(node.expression).mapValue { ThirReturnValue(it) }
+        is HirAssign         -> handle(node)
+        is HirAssignDivide   -> TODO()
+        is HirAssignSubtract -> TODO()
+        is HirAssignModulo   -> TODO()
+        is HirAssignMultiply -> TODO()
+        is HirAssignAdd      -> TODO()
+        is HirBranch         -> handle(node)
+        is HirEvaluate       -> handle(node)
+        is HirReturn         -> ThirReturn.toSuccess()
+        is HirReturnError    -> values.resolve(node.expression).mapValue { ThirReturnError(it) }
+        is HirReturnValue    -> values.resolve(node.expression).mapValue { ThirReturnValue(it) }
     }
     
     private fun handle(node: HirAssign): Result<ThirInstruction, ResolveError>

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Instructions.kt
@@ -15,6 +15,11 @@ sealed interface AstInstruction
  * Assigns the given [expression] to [name], returning the new value of [name].
  */
 data class AstAssign(val name: String, val expression: AstValue) : AstInstruction
+data class AstAssignAdd(val name: String, val expression: AstValue) : AstInstruction
+data class AstAssignDivide(val name: String, val expression: AstValue) : AstInstruction
+data class AstAssignModulo(val name: String, val expression: AstValue) : AstInstruction
+data class AstAssignMultiply(val name: String, val expression: AstValue) : AstInstruction
+data class AstAssignSubtract(val name: String, val expression: AstValue) : AstInstruction
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Control flow

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Values.kt
@@ -18,8 +18,11 @@ sealed interface AstValue
  * All variables are permitted to hold a value, which may be accessed by examining the variable itself. Variables are
  * given a unique [name] within every scope, allowing the analyzer to resolve which variable is being referenced. Any
  * type property will be represented as a variable in the abstract syntax tree.
+ *
+ * The symbol which is loaded can be specialized with any number of [template arguments][temArgs]. These parameters are
+ * specified at compile-time, and parameterizes the loaded object.
  */
-data class AstRead(val name: String) : AstValue
+data class AstLoad(val name: String, val temArgs: List<AstArgument>) : AstValue
 
 /**
  * All procedure calls may either refer to a function with the specified [name] being invoked, or the function operator

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Values.kt
@@ -19,17 +19,17 @@ sealed interface AstValue
  * given a unique [name] within every scope, allowing the analyzer to resolve which variable is being referenced. Any
  * type property will be represented as a variable in the abstract syntax tree.
  *
- * The symbol which is loaded can be specialized with any number of [template arguments][temArgs]. These parameters are
- * specified at compile-time, and parameterizes the loaded object.
+ * The symbol which is loaded can be specialized with any number of compile-time [parameters]. These parameters
+ * parameterize the loaded object, permitting the user to generalize the object over various types and values.
  */
-data class AstLoad(val name: String, val temArgs: List<AstArgument>) : AstValue
+data class AstLoad(val name: String, val parameters: List<AstArgument>) : AstValue
 
 /**
- * All procedure calls may either refer to a function with the specified [name] being invoked, or the function operator
- * being invoked on an instance with the given [name]. Every procedure call is permitted an arbitrary number of
- * [value arguments][valArgs] and [template arguments][temArgs].
+ * All procedure calls may either refer to a function with the specified [instance] being invoked, or the function
+ * operator being invoked on an instance with the given [instance]. Every procedure call is permitted an arbitrary
+ * number of runtime [parameters].
  */
-data class AstCall(val name: String, val temArgs: List<AstArgument>, val valArgs: List<AstArgument>) : AstValue
+data class AstCall(val instance: AstValue, val parameters: List<AstArgument>) : AstValue
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Constants

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
@@ -10,6 +10,11 @@ sealed interface HirInstruction
  * Assigns the specified [expression] to the object located under the given [instance].
  */
 data class HirAssign(val instance: HirValue, val expression: HirValue) : HirInstruction
+data class HirAssignAdd(val instance: HirValue, val expression: HirValue) : HirInstruction
+data class HirAssignDivide(val instance: HirValue, val expression: HirValue) : HirInstruction
+data class HirAssignModulo(val instance: HirValue, val expression: HirValue) : HirInstruction
+data class HirAssignMultiply(val instance: HirValue, val expression: HirValue) : HirInstruction
+data class HirAssignSubtract(val instance: HirValue, val expression: HirValue) : HirInstruction
 
 /**
  * Conditional execution is possible by branching the control flow one a [predicate]. If the predicates matches, the

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
@@ -20,7 +20,7 @@ sealed interface HirValue
  */
 data class HirLoad(
     val name: String,
-    val generics: List<NamedMaybe<HirType>>,
+    val generics: List<NamedMaybe<HirValue>>,
 ) : HirValue
 
 /**

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
@@ -37,11 +37,11 @@ class TestParserExpression
         tester.parse("v[bar = 1]").isChain(1, 4, 1).isValue("v".astLoad("bar" to 1)).resets()
         
         // Calls
-        tester.parse("f()").isChain(1, 1, 1).isValue("f".astCall()).resets()
-        tester.parse("f(1)").isChain(1, 2, 1).isValue("f".astCall(1)).resets()
-        tester.parse("f(1,)").isChain(1, 3, 1).isValue("f".astCall(1)).resets()
-        tester.parse("f(1,2)").isChain(1, 4, 1).isValue("f".astCall(1, 2)).resets()
-        tester.parse("f(bar = 1)").isChain(1, 4, 1).isValue("f".astCall("bar" to 1)).resets()
+        tester.parse("f()").isChain(1, 1, 1).isValue("f".astLoad().astCall()).resets()
+        tester.parse("f(1)").isChain(1, 2, 1).isValue("f".astLoad().astCall(1)).resets()
+        tester.parse("f(1,)").isChain(1, 3, 1).isValue("f".astLoad().astCall(1)).resets()
+        tester.parse("f(1,2)").isChain(1, 4, 1).isValue("f".astLoad().astCall(1, 2)).resets()
+        tester.parse("f(bar = 1)").isChain(1, 4, 1).isValue("f".astLoad().astCall("bar" to 1)).resets()
         
         // Structural
         tester.parse("(1)").isChain(0, 2, 1).isValue(1.ast).resets()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserExpressions.kt
@@ -28,8 +28,15 @@ class TestParserExpression
         tester.parse("\"foo\"").isChain(1).isValue("foo".ast).resets()
         tester.parse("\"bar\"s").isChain(1).isValue("bar".ast).resets()
         
-        // Accesses
-        tester.parse("whatever").isChain(1).isValue("whatever".astRead).resets()
+        // Loads
+        tester.parse("v").isChain(1).isValue("v".astLoad()).resets()
+        tester.parse("v[]").isChain(1, 1, 1).isValue("v".astLoad()).resets()
+        tester.parse("v[1]").isChain(1, 2, 1).isValue("v".astLoad(1)).resets()
+        tester.parse("v[1,]").isChain(1, 3, 1).isValue("v".astLoad(1)).resets()
+        tester.parse("v[1,2]").isChain(1, 4, 1).isValue("v".astLoad(1, 2)).resets()
+        tester.parse("v[bar = 1]").isChain(1, 4, 1).isValue("v".astLoad("bar" to 1)).resets()
+        
+        // Calls
         tester.parse("f()").isChain(1, 1, 1).isValue("f".astCall()).resets()
         tester.parse("f(1)").isChain(1, 2, 1).isValue("f".astCall(1)).resets()
         tester.parse("f(1,)").isChain(1, 3, 1).isValue("f".astCall(1)).resets()

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserStatements.kt
@@ -39,7 +39,7 @@ class TestParserStatement
         tester.parse("return _").isChain(1, 1).isValue(AstReturn)
         
         // Function call
-        tester.parse("a()").isChain(2, 1).isValue(astInvokeOf("a".astCall()))
+        tester.parse("a()").isChain(2, 1).isValue(astInvokeOf("a".astLoad().astCall()))
     }
     
     @Test

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -48,8 +48,8 @@ infix fun Any.astCatchRaise(that: Any) = AstCatch(this.ast, that.ast, Capture.RA
 infix fun Any.astCatchReturn(that: Any) = AstCatch(this.ast, that.ast, Capture.RETURN)
 infix fun Any.astCatchHandle(that: Any) = AstCatch(this.ast, that.ast, Capture.HANDLE)
 
-fun String.astLoad(vararg temArgs: Any) = AstLoad(this, temArgs.map { it.astArg })
-fun String.astCall(vararg valArgs: Any) = AstCall(this, emptyList(), valArgs.map { it.astArg })
+fun String.astLoad(vararg parameters: Any) = AstLoad(this, parameters.map { it.astArg })
+fun AstValue.astCall(vararg parameters: Any) = AstCall(this, parameters.map { it.astArg })
 
 val Any.astArg: AstArgument
     get() = if (this is Pair<*, *>) AstArgument(first as String, (second as Any).ast) else AstArgument(null, ast)

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -48,7 +48,7 @@ infix fun Any.astCatchRaise(that: Any) = AstCatch(this.ast, that.ast, Capture.RA
 infix fun Any.astCatchReturn(that: Any) = AstCatch(this.ast, that.ast, Capture.RETURN)
 infix fun Any.astCatchHandle(that: Any) = AstCatch(this.ast, that.ast, Capture.HANDLE)
 
-val String.astRead: AstRead get() = AstRead(this)
+fun String.astLoad(vararg temArgs: Any) = AstLoad(this, temArgs.map { it.astArg })
 fun String.astCall(vararg valArgs: Any) = AstCall(this, emptyList(), valArgs.map { it.astArg })
 
 val Any.astArg: AstArgument

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -59,11 +59,11 @@ val Any.astArg: AstArgument
 ///////////////////////
 
 infix fun String.astAssign(that: Any) = AstAssign(this, that.ast)
-infix fun String.astAssignAdd(that: Any) = AstAssign(this, AstAdd(AstRead(this), that.ast))
-infix fun String.astAssignSub(that: Any) = AstAssign(this, AstSubtract(AstRead(this), that.ast))
-infix fun String.astAssignMul(that: Any) = AstAssign(this, AstMultiply(AstRead(this), that.ast))
-infix fun String.astAssignMod(that: Any) = AstAssign(this, AstModulo(AstRead(this), that.ast))
-infix fun String.astAssignDiv(that: Any) = AstAssign(this, AstDivide(AstRead(this), that.ast))
+infix fun String.astAssignAdd(that: Any) = AstAssignAdd(this, that.ast)
+infix fun String.astAssignSub(that: Any) = AstAssignSubtract(this, that.ast)
+infix fun String.astAssignMul(that: Any) = AstAssignMultiply(this, that.ast)
+infix fun String.astAssignMod(that: Any) = AstAssignModulo(this, that.ast)
+infix fun String.astAssignDiv(that: Any) = AstAssignDivide(this, that.ast)
 
 val Any.astReturnError get() = AstReturnError(ast)
 val Any.astReturnValue get() = AstReturnValue(ast)


### PR DESCRIPTION
This pull request adds in additional nodes to represent various assignment operations. The nodes which are added represents the instructions `+=`, `-=`, `*=`, `/=`, and `%=`. Such nodes can be overloaded on data types to enable mutating them in-place for more efficient code.

The AST nodes themselves are refactored a bit to better make sense for generics later down the line. Being able to read in the various compile-time parameters will be a requirement for building more generic programs.