### PR TITLE
Add ast node for member access

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/Main.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/Main.kt
@@ -11,9 +11,17 @@ import java.time.Duration
 import java.time.OffsetDateTime
 
 private const val SOURCE = """
+    type Test
+    {
+        val foo: __builtin_i32
+        val bar: __builtin_i32
+    }
+    
     fun main() -> __builtin_i32
     {
-        return fibonacci(25)
+        val test = Test(foo = 2, bar = 23)
+        
+        return fibonacci(test.foo + test.bar)
     }
     
     fun fibonacci(n: __builtin_i32) -> __builtin_i32
@@ -28,18 +36,6 @@ private const val SOURCE = """
             result = fibonacci(n - 2) + fibonacci(n - 1)
 
         return result
-    }
-    
-    type Test
-    {
-        val foo: __builtin_i32
-        val bar: __builtin_i32 = 42
-    }
-    
-    fun test(input: Test)
-    {
-        val a: __builtin_i32 = input.foo
-        val b: __builtin_i32 = input.bar
     }
 """
 
@@ -61,5 +57,5 @@ fun main(args: Array<String>)
     println("Functions: \n\t" + thir.functions.values.joinToString("\n\t") { it.toString() })
     println("Structures: \n\t" + thir.structs.values.joinToString("\n\t") { it.toString() })
     println("Outcome of program is '$outcome'")
-    println("Program took ${Duration.between(start, end)} seconds")
+    println("Program took ${Duration.between(start, end).toNanos() / 1.0e9} seconds")
 }

--- a/src/main/kotlin/com/github/derg/transpiler/Main.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/Main.kt
@@ -19,15 +19,27 @@ private const val SOURCE = """
     fun fibonacci(n: __builtin_i32) -> __builtin_i32
     {
         var result = 0
-        
+
         if n <= 0
             result = 0
         else if n == 1 || n == 2
             result = 1
         else
             result = fibonacci(n - 2) + fibonacci(n - 1)
-        
+
         return result
+    }
+    
+    type Test
+    {
+        val foo: __builtin_i32
+        val bar: __builtin_i32 = 42
+    }
+    
+    fun test(input: Test)
+    {
+        val a: __builtin_i32 = input.foo
+        val b: __builtin_i32 = input.bar
     }
 """
 
@@ -47,6 +59,7 @@ fun main(args: Array<String>)
     val end = OffsetDateTime.now()
     
     println("Functions: \n\t" + thir.functions.values.joinToString("\n\t") { it.toString() })
+    println("Structures: \n\t" + thir.structs.values.joinToString("\n\t") { it.toString() })
     println("Outcome of program is '$outcome'")
     println("Program took ${Duration.between(start, end)} seconds")
 }

--- a/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
@@ -70,51 +70,6 @@ class Interpreter(private val symbols: SymbolTable)
         return evaluateInstructions(frame, instructions)
     }
     
-    private fun evaluateCall(frame: StackFrame, value: ThirCall): ThirValue
-    {
-        val symbol = symbols.functions[(value.instance as ThirLoad).symbolId]
-            ?: throw IllegalArgumentException("No function for value '$value'")
-        val parameters = value.parameters.map { evaluateExpression(frame, it) }
-        
-        // Forgive me Father, for I have sinned.
-        return when (symbol.id)
-        {
-            Builtin.BOOL_AND.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstBool).raw && (evaluateExpression(frame, parameters[1]) as ThirConstBool).raw)
-            Builtin.BOOL_EQ.id   -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstBool).raw == (evaluateExpression(frame, parameters[1]) as ThirConstBool).raw)
-            Builtin.BOOL_NE.id   -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstBool).raw != (evaluateExpression(frame, parameters[1]) as ThirConstBool).raw)
-            Builtin.BOOL_NOT.id  -> ThirConstBool(!(evaluateExpression(frame, parameters[0]) as ThirConstBool).raw)
-            Builtin.BOOL_OR.id   -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstBool).raw || (evaluateExpression(frame, parameters[1]) as ThirConstBool).raw)
-            Builtin.BOOL_XOR.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstBool).raw xor (evaluateExpression(frame, parameters[1]) as ThirConstBool).raw)
-            Builtin.INT32_ADD.id -> ThirConstInt32((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw + (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_DIV.id -> ThirConstInt32((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw / (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_EQ.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw == (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_GE.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw >= (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_GT.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw > (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_LE.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw <= (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_LT.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw < (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_MOD.id -> ThirConstInt32((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw % (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_MUL.id -> ThirConstInt32((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw * (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_NE.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw != (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT32_NEG.id -> ThirConstInt32(-(evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw)
-            Builtin.INT32_POS.id -> ThirConstInt32((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw)
-            Builtin.INT32_SUB.id -> ThirConstInt32((evaluateExpression(frame, parameters[0]) as ThirConstInt32).raw - (evaluateExpression(frame, parameters[1]) as ThirConstInt32).raw)
-            Builtin.INT64_ADD.id -> ThirConstInt64((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw + (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_DIV.id -> ThirConstInt64((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw / (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_EQ.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw == (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_GE.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw >= (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_GT.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw > (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_LE.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw <= (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_LT.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw < (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_MOD.id -> ThirConstInt64((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw % (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_MUL.id -> ThirConstInt64((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw * (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_NE.id  -> ThirConstBool((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw != (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            Builtin.INT64_NEG.id -> ThirConstInt64(-(evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw)
-            Builtin.INT64_POS.id -> ThirConstInt64((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw)
-            Builtin.INT64_SUB.id -> ThirConstInt64((evaluateExpression(frame, parameters[0]) as ThirConstInt64).raw - (evaluateExpression(frame, parameters[1]) as ThirConstInt64).raw)
-            else                 -> pushFrame { evaluate(it, symbol, parameters).valueOrNull() ?: TODO() }
-        }
-    }
-    
     private fun evaluateExpression(frame: StackFrame, value: ThirValue): ThirValue = when (value)
     {
         is ThirCall       -> evaluateCall(frame, value)
@@ -123,7 +78,56 @@ class Interpreter(private val symbols: SymbolTable)
         is ThirConstInt32 -> value
         is ThirConstInt64 -> value
         is ThirLoad       -> frame[value.symbolId]
-        is ThirMember     -> TODO()
+        is ThirMember     -> (evaluateExpression(frame, value.instance) as ThirRecord).fields[value.fieldId]!!
+        is ThirRecord     -> value.apply { fields.forEach { (id, value) -> fields[id] = evaluateExpression(frame, value) } }
+    }
+    
+    private fun evaluateCall(frame: StackFrame, value: ThirCall): ThirValue
+    {
+        val symbol = symbols.functions[(value.instance as ThirLoad).symbolId]
+            ?: throw IllegalArgumentException("No function for value '$value'")
+        
+        // Forgive me Father, for I have sinned...
+        val parameters = value.parameters.map { evaluateExpression(frame, it) }
+        val a = parameters.getOrNull(0)
+        val b = parameters.getOrNull(1)
+        
+        return when (symbol.id)
+        {
+            Builtin.BOOL_AND.id  -> ThirConstBool((a as ThirConstBool).raw && (b as ThirConstBool).raw)
+            Builtin.BOOL_EQ.id   -> ThirConstBool((a as ThirConstBool).raw == (b as ThirConstBool).raw)
+            Builtin.BOOL_NE.id   -> ThirConstBool((a as ThirConstBool).raw != (b as ThirConstBool).raw)
+            Builtin.BOOL_NOT.id  -> ThirConstBool(!(a as ThirConstBool).raw)
+            Builtin.BOOL_OR.id   -> ThirConstBool((a as ThirConstBool).raw || (b as ThirConstBool).raw)
+            Builtin.BOOL_XOR.id  -> ThirConstBool((a as ThirConstBool).raw xor (b as ThirConstBool).raw)
+            Builtin.INT32_ADD.id -> ThirConstInt32((a as ThirConstInt32).raw + (b as ThirConstInt32).raw)
+            Builtin.INT32_DIV.id -> ThirConstInt32((a as ThirConstInt32).raw / (b as ThirConstInt32).raw)
+            Builtin.INT32_EQ.id  -> ThirConstBool((a as ThirConstInt32).raw == (b as ThirConstInt32).raw)
+            Builtin.INT32_GE.id  -> ThirConstBool((a as ThirConstInt32).raw >= (b as ThirConstInt32).raw)
+            Builtin.INT32_GT.id  -> ThirConstBool((a as ThirConstInt32).raw > (b as ThirConstInt32).raw)
+            Builtin.INT32_LE.id  -> ThirConstBool((a as ThirConstInt32).raw <= (b as ThirConstInt32).raw)
+            Builtin.INT32_LT.id  -> ThirConstBool((a as ThirConstInt32).raw < (b as ThirConstInt32).raw)
+            Builtin.INT32_MOD.id -> ThirConstInt32((a as ThirConstInt32).raw % (b as ThirConstInt32).raw)
+            Builtin.INT32_MUL.id -> ThirConstInt32((a as ThirConstInt32).raw * (b as ThirConstInt32).raw)
+            Builtin.INT32_NE.id  -> ThirConstBool((a as ThirConstInt32).raw != (b as ThirConstInt32).raw)
+            Builtin.INT32_NEG.id -> ThirConstInt32(-(a as ThirConstInt32).raw)
+            Builtin.INT32_POS.id -> ThirConstInt32((a as ThirConstInt32).raw)
+            Builtin.INT32_SUB.id -> ThirConstInt32((a as ThirConstInt32).raw - (b as ThirConstInt32).raw)
+            Builtin.INT64_ADD.id -> ThirConstInt64((a as ThirConstInt64).raw + (b as ThirConstInt64).raw)
+            Builtin.INT64_DIV.id -> ThirConstInt64((a as ThirConstInt64).raw / (b as ThirConstInt64).raw)
+            Builtin.INT64_EQ.id  -> ThirConstBool((a as ThirConstInt64).raw == (b as ThirConstInt64).raw)
+            Builtin.INT64_GE.id  -> ThirConstBool((a as ThirConstInt64).raw >= (b as ThirConstInt64).raw)
+            Builtin.INT64_GT.id  -> ThirConstBool((a as ThirConstInt64).raw > (b as ThirConstInt64).raw)
+            Builtin.INT64_LE.id  -> ThirConstBool((a as ThirConstInt64).raw <= (b as ThirConstInt64).raw)
+            Builtin.INT64_LT.id  -> ThirConstBool((a as ThirConstInt64).raw < (b as ThirConstInt64).raw)
+            Builtin.INT64_MOD.id -> ThirConstInt64((a as ThirConstInt64).raw % (b as ThirConstInt64).raw)
+            Builtin.INT64_MUL.id -> ThirConstInt64((a as ThirConstInt64).raw * (b as ThirConstInt64).raw)
+            Builtin.INT64_NE.id  -> ThirConstBool((a as ThirConstInt64).raw != (b as ThirConstInt64).raw)
+            Builtin.INT64_NEG.id -> ThirConstInt64(-(a as ThirConstInt64).raw)
+            Builtin.INT64_POS.id -> ThirConstInt64((a as ThirConstInt64).raw)
+            Builtin.INT64_SUB.id -> ThirConstInt64((a as ThirConstInt64).raw - (b as ThirConstInt64).raw)
+            else                 -> pushFrame { evaluate(it, symbol, parameters).valueOrNull() ?: TODO() }
+        }
     }
 }
 

--- a/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
@@ -123,6 +123,7 @@ class Interpreter(private val symbols: SymbolTable)
         is ThirConstInt32 -> value
         is ThirConstInt64 -> value
         is ThirLoad       -> frame[value.symbolId]
+        is ThirMember     -> TODO()
     }
 }
 

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -142,6 +142,7 @@ internal fun AstValue.toHir(): HirValue = when (this)
 {
     is AstCall         -> HirCall(instance.toHir(), parameters.map { (name, value) -> name to value.toHir() })
     is AstLoad         -> HirLoad(name, parameters.map { (name, value) -> name to value.toHir() })
+    is AstMember       -> TODO()
     is AstBool         -> HirBool(value)
     is AstInteger      -> HirInteger(value, literal)
     is AstDecimal      -> HirDecimal(value, literal)

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -141,8 +141,8 @@ internal fun AstVariable.toHir() = HirVariable(
 internal fun AstValue.toHir(): HirValue = when (this)
 {
     is AstCall         -> HirCall(instance.toHir(), parameters.map { (name, value) -> name to value.toHir() })
-    is AstLoad         -> HirLoad(name, parameters.map { (name, value) -> name to value.toHir() })
-    is AstMember       -> TODO()
+    is AstLoad         -> toHirLoad()
+    is AstMember       -> HirMember(instance.toHir(), field.toHirLoad())
     is AstBool         -> HirBool(value)
     is AstInteger      -> HirInteger(value, literal)
     is AstDecimal      -> HirDecimal(value, literal)
@@ -168,6 +168,8 @@ internal fun AstValue.toHir(): HirValue = when (this)
     is AstXor          -> HirXor(lhs.toHir(), rhs.toHir())
     is AstWhen         -> TODO()
 }
+
+private fun AstLoad.toHirLoad() = HirLoad(name, parameters.map { (name, value) -> name to value.toHir() })
 
 /**
  * Converts [this] statement from AST to HIR. The data structure will be encoded with appropriate default information

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserCombinators.kt
@@ -235,8 +235,7 @@ class ParserOptional<Type>(private val parser: Parser<Type>, private val default
  * parser is also satisfied and may use the [mapper] to produce the final output. This parser may be used recursively as
  * well, i.e. allowing an expression parser to parse another expression while in the middle of parsing.
  */
-class ParserPattern<Type, Out>(private val factory: () -> Parser<Out>, private val mapper: (Out) -> Type) :
-    Parser<Type>
+class ParserPattern<Type, Out>(private val factory: () -> Parser<Out>, private val mapper: (Out) -> Type) : Parser<Type>
 {
     private var parser: Parser<Out>? = null
     

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserInstructions.kt
@@ -45,7 +45,7 @@ private fun assignmentPatternOf() = ParserSequence(
         Symbol.ASSIGN_DIVIDE,
         Symbol.ASSIGN_MODULO,
     ),
-    "rhs" to expressionParserOf(),
+    "rhs" to ParserExpression(),
 )
 
 private fun assignmentOutcomeOf(values: Parsers): AstInstruction =
@@ -59,7 +59,7 @@ private fun branchParserOf(): Parser<AstInstruction> =
 
 private fun branchPatternOf() = ParserSequence(
     "if" to ParserSymbol(Symbol.IF),
-    "predicate" to expressionParserOf(),
+    "predicate" to ParserExpression(),
     "success" to scopeParserOf(),
     "failure" to ParserOptional(ParserPattern(::branchElsePatternOf, ::branchElseOutcomeOf), emptyList()),
 )
@@ -81,7 +81,7 @@ private fun raiseParserOf(): Parser<AstInstruction> =
 
 private fun raisePatternOf() = ParserSequence(
     "symbol" to ParserSymbol(Symbol.RAISE),
-    "expression" to expressionParserOf(),
+    "expression" to ParserExpression(),
 )
 
 private fun raiseOutcomeOf(values: Parsers): AstReturnError =
@@ -95,7 +95,7 @@ private fun returnParserOf(): Parser<AstInstruction> =
 
 private fun returnPatternOf() = ParserSequence(
     "symbol" to ParserSymbol(Symbol.RETURN),
-    "expression" to expressionParserOf(),
+    "expression" to ParserExpression(),
 )
 
 private fun returnOutcomeOf(values: Parsers): AstInstruction
@@ -111,4 +111,4 @@ private fun returnOutcomeOf(values: Parsers): AstInstruction
  */
 // TODO: Not a correct implementation of the parser - must also function with error handling
 private fun invokeParserOf(): Parser<AstInstruction> =
-    ParserPattern(::callParserOf) { AstEvaluate(it) }
+    ParserPattern(::ParserExpression) { AstEvaluate(it) }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserMetadata.kt
@@ -22,7 +22,7 @@ fun valueParserOf(symbol: Symbol): Parser<AstValue> =
     ParserPattern({ valuePatternOf(symbol) }, { it["expression"] })
 
 private fun valuePatternOf(symbol: Symbol) =
-    ParserSequence("symbol" to ParserSymbol(symbol), "expression" to expressionParserOf())
+    ParserSequence("symbol" to ParserSymbol(symbol), "expression" to ParserExpression())
 
 /**
  * Parses a visibility from the token stream.
@@ -102,8 +102,8 @@ fun argumentParserOf(): Parser<NamedMaybe<AstValue>> =
     ParserPattern(::argumentPatternOf, ::argumentOutcomeOf)
 
 private fun argumentPatternOf() = ParserAnyOf(
-    ParserSequence("expr" to expressionParserOf()),
-    ParserSequence("name" to ParserIdentifier(), "sym" to ParserSymbol(Symbol.ASSIGN), "expr" to expressionParserOf()),
+    ParserSequence("expr" to ParserExpression()),
+    ParserSequence("name" to ParserIdentifier(), "sym" to ParserSymbol(Symbol.ASSIGN), "expr" to ParserExpression()),
 )
 
 private fun argumentOutcomeOf(values: Parsers): NamedMaybe<AstValue> =

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserSymbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserSymbols.kt
@@ -25,7 +25,7 @@ private fun constantPatternOf() = ParserSequence(
     "colon" to ParserSymbol(Symbol.COLON),
     "type" to typeParserOf(),
     "op" to ParserSymbol(Symbol.ASSIGN),
-    "value" to expressionParserOf(),
+    "value" to ParserExpression(),
 )
 
 private fun constantOutcomeOf(values: Parsers) = AstConstant(
@@ -97,7 +97,7 @@ private fun variablePatternOf() = ParserSequence(
     "name" to ParserIdentifier(),
     "type" to optionalTypeParserOf(Symbol.COLON),
     "op" to ParserSymbol(Symbol.ASSIGN),
-    "value" to expressionParserOf(),
+    "value" to ParserExpression(),
 )
 
 private fun variableOutcomeOf(values: Parsers) = AstVariable(

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserValues.kt
@@ -2,129 +2,179 @@ package com.github.derg.transpiler.phases.parser
 
 import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.ast.*
+import com.github.derg.transpiler.source.lexeme.*
+import com.github.derg.transpiler.utils.*
 
 /**
- * Operators have a specific precedence associated with them. The higher the precedence, the later they are evaluated in
- * the expression. In other words, operators with the lowest precedence are evaluated first.
+ * Operators have a specific [precedence] associated with them. The higher the precedence, the later they are evaluated
+ * in the expression. In other words, operators with the lowest precedence are evaluated first.
  *
  * Note that this table is not a complete set of all possible operators. Certain structural operators, such as
  * parenthesis, may be used to alter the precedence. The positioning of the operator also makes a difference - all
  * prefix operators (such as unary plus and minus) target only the expression to their immediate right, whereas postfix
  * operators target the entire expression so far to the left.
  */
-private val PRECEDENCE = mapOf(
-    Symbol.AND to 4,
-    Symbol.DIVIDE to 0,
-    Symbol.EQUAL to 3,
-    Symbol.EXCLAMATION to 7,
-    Symbol.GREATER to 3,
-    Symbol.GREATER_EQUAL to 3,
-    Symbol.LESS to 3,
-    Symbol.LESS_EQUAL to 3,
-    Symbol.MINUS to 1,
-    Symbol.MODULO to 0,
-    Symbol.MULTIPLY to 0,
-    Symbol.NOT_EQUAL to 3,
-    Symbol.OR to 5,
-    Symbol.PLUS to 1,
-    Symbol.QUESTION to 7,
-    Symbol.THREE_WAY to 2,
-    Symbol.XOR to 6,
-)
-
-/**
- * Joins together the [lhs] and [rhs] expression using the specified [operator].
- */
-private fun mergeInfix(lhs: AstValue, operator: Symbol, rhs: AstValue): AstValue = when (operator)
+private enum class BinaryOperator(val apply: (AstValue, AstValue) -> AstValue, val precedence: Int)
 {
-    Symbol.AND           -> AstAnd(lhs, rhs)
-    Symbol.DIVIDE        -> AstDivide(lhs, rhs)
-    Symbol.EQUAL         -> AstEqual(lhs, rhs)
-    Symbol.EXCLAMATION   -> AstCatch(lhs, rhs, Capture.RAISE)
-    Symbol.GREATER       -> AstGreater(lhs, rhs)
-    Symbol.GREATER_EQUAL -> AstGreaterEqual(lhs, rhs)
-    Symbol.LESS          -> AstLess(lhs, rhs)
-    Symbol.LESS_EQUAL    -> AstLessEqual(lhs, rhs)
-    Symbol.MINUS         -> AstSubtract(lhs, rhs)
-    Symbol.MODULO        -> AstModulo(lhs, rhs)
-    Symbol.MULTIPLY      -> AstMultiply(lhs, rhs)
-    Symbol.NOT_EQUAL     -> AstNotEqual(lhs, rhs)
-    Symbol.OR            -> AstOr(lhs, rhs)
-    Symbol.PLUS          -> AstAdd(lhs, rhs)
-    Symbol.QUESTION      -> AstCatch(lhs, rhs, Capture.RETURN)
-    Symbol.THREE_WAY     -> AstThreeWay(lhs, rhs)
-    Symbol.XOR           -> AstXor(lhs, rhs)
-    else                 -> throw IllegalStateException("Illegal operator $operator when parsing operator")
+    AND(::AstAnd, 4),
+    ADD(::AstAdd, 1),
+    DIV(::AstDivide, 0),
+    EQ(::AstEqual, 3),
+    GT(::AstGreater, 3),
+    GE(::AstGreaterEqual, 3),
+    LT(::AstLess, 3),
+    LE(::AstLessEqual, 3),
+    MOD(::AstModulo, 0),
+    MUL(::AstMultiply, 0),
+    NE(::AstNotEqual, 3),
+    OR(::AstOr, 5),
+    SUB(::AstSubtract, 1),
+    TW(::AstThreeWay, 2),
+    XOR(::AstXor, 6),
+    // TODO: Please refactor these into something more sane :(
+    EXCLAMATION({ lhs, rhs -> AstCatch(lhs, rhs, Capture.RAISE) }, 7),
+    QUESTION({ lhs, rhs -> AstCatch(lhs, rhs, Capture.RETURN) }, 7),
 }
 
-/**
- * Joins together the prefix [operator] and the [rhs] expression.
- */
-private fun mergePrefix(operator: Symbol, rhs: AstValue): AstValue = when (operator)
+private enum class UnaryOperator(val apply: (AstValue) -> AstValue)
 {
-    Symbol.NOT   -> AstNot(rhs)
-    Symbol.PLUS  -> AstPlus(rhs)
-    Symbol.MINUS -> AstMinus(rhs)
-    else         -> throw IllegalStateException("Illegal operator $operator when parsing prefix operator")
+    PLUS(::AstPlus),
+    MINUS(::AstMinus),
+    NOT(::AstNot),
 }
 
 /**
  * Joins together the [lhs] expression together with the remainder of the [terms], in a recursive manner.
  */
-private fun mergeTerms(lhs: AstValue, terms: List<Pair<Symbol, AstValue>>, index: Int = 0): AstValue
+private fun mergeTerms(lhs: AstValue, terms: List<Pair<BinaryOperator, AstValue>>, index: Int = 0): AstValue
 {
     val (op1, mhs) = terms.getOrNull(index) ?: return lhs
-    val (op2, rhs) = terms.getOrNull(index + 1) ?: return mergeInfix(lhs, op1, mhs)
+    val (op2, rhs) = terms.getOrNull(index + 1) ?: return op1.apply(lhs, mhs)
     
-    // If next operator has higher precedence, parse left-hand of tree first
-    if (PRECEDENCE[op1]!! <= PRECEDENCE[op2]!!)
-        return mergeTerms(mergeInfix(lhs, op1, mhs), terms, index + 1)
-    
-    // Otherwise, the remainder right-hand side must be parsed recursively
-    val rest = mergeTerms(mergeInfix(mhs, op2, rhs), terms, index + 2)
-    return mergeInfix(lhs, op1, rest)
+    // If next operator has higher precedence, parse left-hand of tree first. Otherwise, the remainder right-hand side
+    // must be parsed recursively
+    if (op1.precedence <= op2.precedence)
+        return mergeTerms(op1.apply(lhs, mhs), terms, index + 1)
+    return op1.apply(lhs, mergeTerms(op2.apply(mhs, rhs), terms, index + 2))
 }
 
 /**
- * Parses a single expression from the token stream.
+ * Parses an expression from the token stream. The expressions are parsed recursively, where sub-expressions can be
+ * nested within parenthesis.
  */
-fun expressionParserOf(): Parser<AstValue> =
-    ParserPattern(::expressionPatternOf, ::expressionOutcomeOf)
-
-private fun basePatternOf() = ParserAnyOf(
-    ParserBool(),
-    ParserInteger(),
-    ParserText(),
-    loadParserOf(),
-    callParserOf(),
-    parenthesisParserOf(),
-    unaryOperatorParserOf(),
-    whenParserOf(),
-)
-
-private fun termPatternOf() = ParserSequence(
-    "operator" to ParserSymbol(*PRECEDENCE.keys.toTypedArray()), // Note: This handles all infix operators
-    "term" to basePatternOf(),
-)
-
-private fun expressionPatternOf() = ParserSequence(
-    "base" to basePatternOf(),
-    "terms" to ParserRepeating(termPatternOf()),
-)
-
-private fun expressionOutcomeOf(values: Parsers): AstValue
+internal class ParserExpression : Parser<AstValue>
 {
-    val base = values.get<AstValue>("base")
-    val terms = values.get<List<Parsers>>("terms")
-    val ops = terms.produce<Symbol>("operator")
-    val rest = terms.produce<AstValue>("term")
-    return mergeTerms(base, ops zip rest)
+    private var inner: Parser<AstValue>? = null
+    private val terms = mutableListOf<AstValue>()
+    private val unary = mutableListOf<UnaryOperator>()
+    private val binary = mutableListOf<BinaryOperator>()
+    
+    override fun reset()
+    {
+        inner = null
+        terms.clear()
+        unary.clear()
+        binary.clear()
+    }
+    
+    override fun skipable(): Boolean = false
+    
+    override fun produce(): AstValue
+    {
+        if (terms.isEmpty())
+            throw IllegalStateException("Expected at least one element in expression")
+        if (terms.size != binary.size + 1)
+            throw IllegalStateException("Expected one less binary operator than number of terms")
+        
+        val lhs = terms.first()
+        val terms = binary.withIndex().map { (index, op) -> op to terms[index + 1] }
+        return mergeTerms(lhs, terms)
+    }
+    
+    override fun parse(token: Token): Result<ParseOk, ParseError>
+    {
+        // If we are not currently preoccupied with parsing a sub-expression, we need to determine what we are parsing.
+        // At this point, we must find a valid value, or something which starts off as a unary operator.
+        if (inner == null) when (token)
+        {
+            is Identifier -> inner = loadParserOf()
+            is Keyword    -> when (token.type)
+            {
+                Symbol.TRUE             -> inner = ParserBool()
+                Symbol.FALSE            -> inner = ParserBool()
+                Symbol.OPEN_PARENTHESIS -> inner = parenthesisParserOf()
+                Symbol.WHEN             -> inner = whenParserOf()
+                Symbol.PLUS             -> unary.add(UnaryOperator.PLUS)
+                Symbol.MINUS            -> unary.add(UnaryOperator.MINUS)
+                Symbol.NOT              -> unary.add(UnaryOperator.NOT)
+                else                    -> return ParseError.UnexpectedToken(token).toFailure()
+            }
+            is Numeric    -> inner = ParserInteger()
+            is Textual    -> inner = ParserText()
+            else          -> return ParseError.UnexpectedToken(token).toFailure()
+        }
+        
+        // If we have an inner parser at this point, we are working on some leaf value, or we have found a new unary
+        // operator to take into consideration. If we are working with a unary operator, we must find another value to
+        // work with and can bail early. Otherwise, we must invoke the inner parser to figure out what to do next.
+        val inner = inner ?: return ParseOk.Incomplete.toSuccess()
+        
+        val outcome = inner.parse(token).valueOr { return it.toFailure() }
+        if (outcome !is ParseOk.Finished)
+            return outcome.toSuccess()
+        
+        // At this point, the inner parser is done as it encountered a token which it cannot do anything else with.
+        // Here, we have either stumbled upon a binary operator, a function call, or a field access. In all cases, we
+        // must consume the value and reset the inner parser for now.
+        var done = false
+        if (token is Keyword) when (token.type)
+        {
+            Symbol.PERIOD           -> this.inner = memberParserOf(inner.produce())
+            Symbol.OPEN_PARENTHESIS -> this.inner = callParserOf(inner.produce())
+            Symbol.AND              -> consumeSubExpression().also { binary.add(BinaryOperator.AND) }
+            Symbol.DIVIDE           -> consumeSubExpression().also { binary.add(BinaryOperator.DIV) }
+            Symbol.EQUAL            -> consumeSubExpression().also { binary.add(BinaryOperator.EQ) }
+            Symbol.EXCLAMATION      -> consumeSubExpression().also { binary.add(BinaryOperator.EXCLAMATION) }
+            Symbol.GREATER          -> consumeSubExpression().also { binary.add(BinaryOperator.GT) }
+            Symbol.GREATER_EQUAL    -> consumeSubExpression().also { binary.add(BinaryOperator.GE) }
+            Symbol.LESS             -> consumeSubExpression().also { binary.add(BinaryOperator.LT) }
+            Symbol.LESS_EQUAL       -> consumeSubExpression().also { binary.add(BinaryOperator.LE) }
+            Symbol.MINUS            -> consumeSubExpression().also { binary.add(BinaryOperator.SUB) }
+            Symbol.MODULO           -> consumeSubExpression().also { binary.add(BinaryOperator.MOD) }
+            Symbol.MULTIPLY         -> consumeSubExpression().also { binary.add(BinaryOperator.MUL) }
+            Symbol.NOT_EQUAL        -> consumeSubExpression().also { binary.add(BinaryOperator.NE) }
+            Symbol.OR               -> consumeSubExpression().also { binary.add(BinaryOperator.OR) }
+            Symbol.PLUS             -> consumeSubExpression().also { binary.add(BinaryOperator.ADD) }
+            Symbol.QUESTION         -> consumeSubExpression().also { binary.add(BinaryOperator.QUESTION) }
+            Symbol.THREE_WAY        -> consumeSubExpression().also { binary.add(BinaryOperator.TW) }
+            Symbol.XOR              -> consumeSubExpression().also { binary.add(BinaryOperator.XOR) }
+            else                    -> consumeSubExpression().also { done = true }
+        }
+        else
+            consumeSubExpression().also { done = true }
+        
+        // If we did not encounter more work to be done, we are finished. Otherwise, we must
+        return if (done) ParseOk.Finished.toSuccess() else ParseOk.Incomplete.toSuccess()
+    }
+    
+    /**
+     * Consumes the inner parser value, with all unary operators applied to the produced value at the same time. This
+     * should only be invoked once there are no more recursive components left to parse.
+     */
+    private fun consumeSubExpression()
+    {
+        var term = inner?.produce() ?: throw IllegalStateException("Expected to have an inner parser, none is active")
+        inner = null
+        unary.asReversed().forEach { term = it.apply(term) }
+        unary.clear()
+        terms.add(term)
+    }
 }
 
 /**
  * Parses a variable access expression from the token stream.
  */
-private fun loadParserOf(): Parser<AstValue> =
+private fun loadParserOf(): Parser<AstLoad> =
     ParserPattern(::loadPatternOf, ::loadOutcomeOf)
 
 private fun loadPatternOf() = ParserSequence(
@@ -136,53 +186,38 @@ private fun loadPatternOf() = ParserSequence(
     ))
 )
 
-private fun loadOutcomeOf(outcome: Parsers): AstValue =
+private fun loadOutcomeOf(outcome: Parsers): AstLoad =
     AstLoad(outcome["name"], outcome.get<Parsers?>("params")?.get("params") ?: emptyList())
+
+/**
+ * Parses a field access expression from the token stream.
+ */
+private fun memberParserOf(instance: AstValue): Parser<AstValue> =
+    ParserPattern(::loadParserOf) { AstMember(instance, it) }
 
 /**
  * Parses a function call expression from the token stream.
  */
-internal fun callParserOf(): Parser<AstValue> =
-    ParserPattern(::callPatternOf, ::callOutcomeOf)
+private fun callParserOf(instance: AstValue): Parser<AstValue> =
+    ParserPattern(::callPatternOf) { AstCall(instance, it["params"]) }
 
 private fun callPatternOf() = ParserSequence(
-    "name" to ParserIdentifier(),
-    "open" to ParserSymbol(Symbol.OPEN_PARENTHESIS),
+    // NOTE: We are omitting the open parenthesis since it is consumed by the expression parser instead.
     "params" to ParserRepeating(argumentParserOf(), ParserSymbol(Symbol.COMMA)),
     "close" to ParserSymbol(Symbol.CLOSE_PARENTHESIS),
 )
-
-private fun callOutcomeOf(outcome: Parsers): AstValue =
-    AstCall(AstLoad(outcome["name"], emptyList()), outcome["params"])
 
 /**
  * Parses an expression from in-between parenthesis from the token stream.
  */
 private fun parenthesisParserOf(): Parser<AstValue> =
-    ParserPattern(::parenthesisPatternOf, ::parenthesisOutcomeOf)
+    ParserPattern(::parenthesisPatternOf) { it["expr"] }
 
 private fun parenthesisPatternOf() = ParserSequence(
     "open" to ParserSymbol(Symbol.OPEN_PARENTHESIS),
-    "expr" to expressionParserOf(),
+    "expr" to ParserExpression(),
     "close" to ParserSymbol(Symbol.CLOSE_PARENTHESIS),
 )
-
-private fun parenthesisOutcomeOf(values: Parsers): AstValue =
-    values["expr"]
-
-/**
- * Parses a unary operator from the token stream.
- */
-private fun unaryOperatorParserOf(): Parser<AstValue> =
-    ParserPattern(::unaryOperatorPatternOf, ::unaryOperatorOutcomeOf)
-
-private fun unaryOperatorPatternOf() = ParserSequence(
-    "op" to ParserSymbol(Symbol.PLUS, Symbol.MINUS, Symbol.NOT),
-    "rhs" to basePatternOf(),
-)
-
-private fun unaryOperatorOutcomeOf(values: Parsers): AstValue =
-    mergePrefix(values["op"], values["rhs"])
 
 /**
  * Parses a when expression from the token stream.
@@ -192,10 +227,10 @@ private fun whenParserOf(): Parser<AstValue> =
 
 private fun whenPatternOf() = ParserSequence(
     "when" to ParserSymbol(Symbol.WHEN),
-    "expression" to expressionParserOf(),
+    "expression" to ParserExpression(),
     "first" to whenBranchParserOf(),
     "remainder" to ParserRepeating(whenBranchParserOf()),
-    "else" to ParserOptional(ParserSequence("else" to ParserSymbol(Symbol.ELSE), "expr" to expressionParserOf())),
+    "else" to ParserOptional(ParserSequence("else" to ParserSymbol(Symbol.ELSE), "expr" to ParserExpression())),
 )
 
 private fun whenOutcomeOf(values: Parsers): AstValue
@@ -214,9 +249,9 @@ private fun whenBranchParserOf(): Parser<Pair<AstValue, AstValue>> =
     ParserPattern(::whenBranchPatternOf, ::whenBranchOutcomeOf)
 
 private fun whenBranchPatternOf() = ParserSequence(
-    "condition" to expressionParserOf(),
+    "condition" to ParserExpression(),
     "separator" to ParserSymbol(Symbol.ARROW),
-    "expression" to expressionParserOf(),
+    "expression" to ParserExpression(),
 )
 
 private fun whenBranchOutcomeOf(values: Parsers): Pair<AstValue, AstValue>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
@@ -19,7 +19,7 @@ fun resolve(program: HirProgram): Result<SymbolTable, ResolveError>
     // TODO: Obviously find a better way to access the contents of the package. The engine should take care of the heavy
     //       lifting, going through the modules and segments. The order in which modules are handled does matter - we
     //       must ensure that modules which depends on others, are resolved last.
-    program.applications.single().structs.forEach { inner.register(it) }
+    program.applications.single().structs.forEach { inner.register(it); inner.register(it.constructor) }
     program.applications.single().functions.forEach { inner.register(it) }
     
     // Make sure that all symbols present within the package are handled appropriately.

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
@@ -131,16 +131,16 @@ internal class ResolutionEngine
      * the scope are
      */
     fun prepare(scope: Scope): Result<Unit, ResolveError> =
-        PreparerSymbol(types, scope).prepare(scope.symbols).resolve()
+        PreparerSymbol(symbols, types, scope).prepare(scope.symbols).resolve()
     
     fun resolve(scope: Scope, node: HirSymbol): Result<ThirSymbol, ResolveError> =
         ResolverSymbol(symbols, types, scope).resolve(node)
     
     fun resolve(scope: Scope, node: HirValue): Result<ThirValue, ResolveError> =
-        ResolverValue(types, scope).resolve(node)
+        ResolverValue(symbols, types, scope).resolve(node)
     
     fun resolve(scope: Scope, node: HirInstruction): Result<ThirInstruction, ResolveError> =
-        ResolverInstruction(types, scope).resolve(node)
+        ResolverInstruction(symbols, types, scope).resolve(node)
 }
 
 /**
@@ -150,10 +150,10 @@ internal class ResolutionEngine
  * Note that type-checking is not performed at this phase. We only make sure that the type information is generates for
  * all symbols which need such information.
  */
-private class PreparerSymbol(private val table: TypeTable, scope: Scope)
+private class PreparerSymbol(symbols: SymbolTable, private val table: TypeTable, scope: Scope)
 {
-    private val types = ResolverType(scope)
-    private val values = ResolverValue(table, scope)
+    private val typeResolver = ResolverType(scope)
+    private val valueResolver = ResolverValue(symbols, table, scope)
     
     // Collection of symbols which remains to be processed, in the exact order they should be processed.
     private val queue = ArrayDeque<HirSymbol>()
@@ -196,24 +196,24 @@ private class PreparerSymbol(private val table: TypeTable, scope: Scope)
     
     private fun handle(symbol: HirField): Result<Unit, ResolveError>
     {
-        table.fields[symbol.id] = types.resolve(symbol.type).valueOr { return it.toFailure() }
+        table.fields[symbol.id] = typeResolver.resolve(symbol.type).valueOr { return it.toFailure() }
         
         return Unit.toSuccess()
     }
     
     private fun handle(symbol: HirFunction): Result<Unit, ResolveError>
     {
-        table.functions[symbol.id] = types.resolve(symbol.type).valueOr { return it.toFailure() }
+        table.functions[symbol.id] = typeResolver.resolve(symbol.type).valueOr { return it.toFailure() }
 
 //        prepare(symbol.generics)
-        prepare(symbol.variables)
         prepare(symbol.parameters)
+        prepare(symbol.variables)
         return Unit.toSuccess()
     }
     
     private fun handle(symbol: HirLiteral): Result<Unit, ResolveError>
     {
-        table.literals[symbol.id] = types.resolve(symbol.type).valueOr { return it.toFailure() }
+        table.literals[symbol.id] = typeResolver.resolve(symbol.type).valueOr { return it.toFailure() }
 
 //        prepare(symbol.variables)
         prepare(listOf(symbol.parameter))
@@ -222,7 +222,7 @@ private class PreparerSymbol(private val table: TypeTable, scope: Scope)
     
     private fun handle(symbol: HirParameter): Result<Unit, ResolveError>
     {
-        table.parameters[symbol.id] = types.resolve(symbol.type).valueOr { return it.toFailure() }
+        table.parameters[symbol.id] = typeResolver.resolve(symbol.type).valueOr { return it.toFailure() }
         
         return Unit.toSuccess()
     }
@@ -237,10 +237,10 @@ private class PreparerSymbol(private val table: TypeTable, scope: Scope)
     
     private fun handle(symbol: HirVariable): Result<Unit, ResolveError>
     {
-        val type = symbol.type?.let { types.resolve(it) }?.valueOr { return it.toFailure() }
-        val value = values.resolve(symbol.value).valueOr { return it.toFailure() }
+        val type = symbol.type?.let { typeResolver.resolve(it) }?.valueOr { return it.toFailure() }
+        val value = valueResolver.resolve(symbol.value).mapValue { it.value }.valueOr { type ?: return it.toFailure() }
         
-        table.variables[symbol.id] = type ?: value.value ?: return ResolveError.TypeMissing(symbol.name, symbol.value).toFailure()
+        table.variables[symbol.id] = type ?: value ?: return ResolveError.TypeMissing(symbol.name, symbol.value).toFailure()
         
         return Unit.toSuccess()
     }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
@@ -12,9 +12,9 @@ import com.github.derg.transpiler.utils.*
  * All instruction resolution takes place before the symbol table has been constructed. This implies that the symbol
  * table cannot be used while resolving instructions.
  */
-internal class ResolverInstruction(private val types: TypeTable, private val scope: Scope)
+internal class ResolverInstruction(symbols: SymbolTable, private val types: TypeTable, private val scope: Scope)
 {
-    private val values = ResolverValue(types, scope)
+    private val values = ResolverValue(symbols, types, scope)
     
     /**
      * Converts the instruction indicated by the [node] to a typed version. This operation converts all raw names into

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverSymbols.kt
@@ -40,7 +40,7 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
             id = node.id,
             name = node.name,
             type = types.fields[node.id]!!,
-            value = node.value?.let { ResolverValue(types, scope).resolve(it) }?.valueOr { return it.toFailure() },
+            value = node.value?.let { ResolverValue(symbols, types, scope).resolve(it) }?.valueOr { return it.toFailure() },
             visibility = node.visibility,
             assignability = node.assignability,
         )
@@ -52,20 +52,20 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
     private fun handle(node: HirFunction): Result<ThirSymbol, ResolveError>
     {
         val inner = Scope(scope)
-    
+
 //        node.generics.forEach { inner.register(it) }
-        node.variables.forEach { inner.register(it) }
         node.parameters.forEach { inner.register(it) }
+        node.variables.forEach { inner.register(it) }
 //        node.generics.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
-        node.variables.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
         node.parameters.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
+        node.variables.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
         
         val symbol = ThirFunction(
             id = node.id,
             name = node.name,
             type = types.functions[node.id]!!,
             visibility = node.visibility,
-            instructions = node.instructions.mapUntilError { ResolverInstruction(types, inner).resolve(it) }.valueOr { return it.toFailure() },
+            instructions = node.instructions.mapUntilError { ResolverInstruction(symbols, types, inner).resolve(it) }.valueOr { return it.toFailure() },
             genericIds = node.generics.map { it.id },
             variableIds = node.variables.map { it.id },
             parameterIds = node.parameters.map { it.id },
@@ -78,7 +78,7 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
     private fun handle(node: HirLiteral): Result<ThirSymbol, ResolveError>
     {
         val inner = Scope(scope)
-
+        
         node.variables.forEach { inner.register(it) }
         inner.register(node.parameter)
         node.variables.mapUntilError { handle(it) }.onFailure { return it.toFailure() }
@@ -89,7 +89,7 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
             name = node.name,
             type = types.literals[node.id]!!,
             visibility = node.visibility,
-            instructions = node.instructions.mapUntilError { ResolverInstruction(types, inner).resolve(it) }.valueOr { return it.toFailure() },
+            instructions = node.instructions.mapUntilError { ResolverInstruction(symbols, types, inner).resolve(it) }.valueOr { return it.toFailure() },
             genericIds = emptyList(),
             variableIds = node.variables.map { it.id },
             parameterIds = listOf(node.parameter.id),
@@ -105,7 +105,7 @@ internal class ResolverSymbol(private val symbols: SymbolTable, private val type
             id = node.id,
             name = node.name,
             type = types.parameters[node.id]!!,
-            value = node.value?.let { ResolverValue(types, scope).resolve(it) }?.valueOr { return it.toFailure() },
+            value = node.value?.let { ResolverValue(symbols, types, scope).resolve(it) }?.valueOr { return it.toFailure() },
             passability = node.passability,
         )
         

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -12,7 +12,7 @@ fun check(table: SymbolTable): Result<Unit, TypeError>
 {
     for (function in table.functions.values)
     {
-        val checker = CheckerInstruction(function.type.value, function.type.error)
+        val checker = CheckerInstruction(table, function.type.value, function.type.error)
         
         function.instructions.mapUntilError { checker.check(it) }.valueOr { return it.toFailure() }
     }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.typechecker
 
+import com.github.derg.transpiler.phases.resolver.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
@@ -8,7 +9,7 @@ import com.github.derg.transpiler.utils.*
  * The instruction checker ensures that all instructions within some contexts are valid. The instructions are expected
  * to output the [value] and [error] types, if they are specified. For some instructions, the types are not applicable.
  */
-internal class CheckerInstruction(private val value: ThirType?, private val error: ThirType?)
+internal class CheckerInstruction(private val symbols: SymbolTable, private val value: ThirType?, private val error: ThirType?)
 {
     /**
      * Performs type-checking on the instruction [node]. If there are any type errors detected, an error is returned.
@@ -35,6 +36,7 @@ internal class CheckerInstruction(private val value: ThirType?, private val erro
         // TODO: Support generics.
         // TODO: Support mutable types.
         // TODO: Support union types.
+        val value = symbols.variables[node.symbolId]?.type
         if (value != node.expression.value)
             return TypeError.AssignWrongType(node.expression).toFailure()
     

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -17,6 +17,7 @@ internal class CheckerValue
         is ThirCall       -> handle(node)
         is ThirCatch      -> handle(node)
         is ThirLoad       -> handle(node)
+        is ThirMember     -> handle(node)
         is ThirConstBool  -> Unit.toSuccess()
         is ThirConstInt32 -> Unit.toSuccess()
         is ThirConstInt64 -> Unit.toSuccess()
@@ -65,6 +66,12 @@ internal class CheckerValue
     }
     
     private fun handle(node: ThirLoad): Result<Unit, TypeError>
+    {
+        // TODO: Implement me.
+        return Unit.toSuccess()
+    }
+    
+    private fun handle(node: ThirMember): Result<Unit, TypeError>
     {
         // TODO: Implement me.
         return Unit.toSuccess()

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -18,6 +18,7 @@ internal class CheckerValue
         is ThirCatch      -> handle(node)
         is ThirLoad       -> handle(node)
         is ThirMember     -> handle(node)
+        is ThirRecord     -> Unit.toSuccess()
         is ThirConstBool  -> Unit.toSuccess()
         is ThirConstInt32 -> Unit.toSuccess()
         is ThirConstInt64 -> Unit.toSuccess()

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Values.kt
@@ -32,6 +32,13 @@ data class AstLoad(val name: String, val parameters: List<NamedMaybe<AstValue>>)
  */
 data class AstCall(val instance: AstValue, val parameters: List<NamedMaybe<AstValue>>) : AstValue
 
+/**
+ * Various data structures can have any number of attributes associated with them. These attributes can be accessed on
+ * any valid [instance] expression. Both attributes and methods may be accessed through the [field] expression; only
+ * methods can also be parameterized with compile-time parameters, however.
+ */
+data class AstMember(val instance: AstValue, val field: AstLoad) : AstValue
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Constants
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
@@ -24,19 +24,6 @@ data class HirLoad(
 ) : HirValue
 
 /**
- * Retrieves the value of the given [field] from the given [instance]. The object may be an object which exists on the
- * stack or heap. When referring to a method, [generics] may be used to disambiguate which method is intended.
- */
-// TODO: Should objects within modules be accessible via this value? Possibly yes, to unify instance and module access.
-//       In doing so, the syntax could be simplified, using only `foo.bar`, instead of also including `foo::bar`. The
-//       downside being name resolution becomes much more finicky as modules cannot have the same names as other items.
-data class HirRead(
-    val instance: HirValue,
-    val field: String,
-    val generics: List<NamedMaybe<HirType>>,
-) : HirValue
-
-/**
  * Invokes the callable [instance] using the provided [parameters]. The arguments are specified in the same order in
  * which they appear in source code. In some cases, the callable cannot be resolved without additional information about
  * the callable template specialization.
@@ -44,6 +31,15 @@ data class HirRead(
 data class HirCall(
     val instance: HirValue,
     val parameters: List<NamedMaybe<HirValue>>,
+) : HirValue
+
+/**
+ * Retrieves the value of the given [field] from the given [instance]. The object may be an object which exists on the
+ * stack or heap.
+ */
+data class HirMember(
+    val instance: HirValue,
+    val field: HirLoad,
 ) : HirValue
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Values.kt
@@ -3,6 +3,7 @@ package com.github.derg.transpiler.source.hir
 import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.utils.*
 import java.math.*
+import java.util.*
 
 /**
  *
@@ -40,6 +41,15 @@ data class HirCall(
 data class HirMember(
     val instance: HirValue,
     val field: HirLoad,
+) : HirValue
+
+/**
+ * An instance of a structure fo the given [symbolId], containing a selection of values in its [fields]. All values are
+ * associated with a specific field.
+ */
+data class HirRecord(
+    val symbolId: UUID,
+    val fields: Map<UUID, HirValue>,
 ) : HirValue
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
@@ -40,6 +40,18 @@ data class ThirCall(
 ) : ThirValue
 
 /**
+ *
+ */
+data class ThirMember(
+    override val value: ThirType?,
+    val instance: ThirValue,
+    val fieldId: UUID,
+) : ThirValue
+{
+    override val error: Nothing? get() = null
+}
+
+/**
  * Represents the outcome of capturing an error in [lhs], and replacing the error case with the value in [rhs].
  * Depending on the [capture] mode, the resulting value is used either in the original expression in place of the
  * success value, or raised/returned from the callable object.

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
@@ -40,12 +40,23 @@ data class ThirCall(
 ) : ThirValue
 
 /**
- *
+ * Accesses a specific [fieldId] within the structure referenced to by the [instance].
  */
 data class ThirMember(
-    override val value: ThirType?,
+    override val value: ThirType,
     val instance: ThirValue,
     val fieldId: UUID,
+) : ThirValue
+{
+    override val error: Nothing? get() = null
+}
+
+/**
+ * Instance of a structure.
+ */
+data class ThirRecord(
+    override val value: ThirType,
+    val fields: MutableMap<UUID, ThirValue>,
 ) : ThirValue
 {
     override val error: Nothing? get() = null

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserInstructions.kt
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.*
  * number of tokens resulting in [ParseOk.Incomplete], followed by [postOkCount] [ParseOk.Complete], before finally
  * resulting in [ParseOk.Finished].
  */
-private fun <Type> Tester<Type>.isChain(wipCount: Int = 0, postOkCount: Int = 0): Tester<Type> =
-    isWip(wipCount).isOk(postOkCount).isDone()
+private fun <Type> Tester<Type>.isChain(preOkCount: Int = 0, wipCount: Int = 0, postOkCount: Int = 0): Tester<Type> =
+    isOk(preOkCount).isWip(wipCount).isOk(postOkCount).isDone()
 
 class TestParserStatement
 {
@@ -20,32 +20,32 @@ class TestParserStatement
     fun `Given valid token, when parsing, then correct statement`()
     {
         // Assignments
-        tester.parse("a = 1").isChain(2, 1).isValue("a" astAssign 1)
-        tester.parse("a += 1").isChain(2, 1).isValue("a" astAssignAdd 1)
-        tester.parse("a -= 1").isChain(2, 1).isValue("a" astAssignSub 1)
-        tester.parse("a *= 1").isChain(2, 1).isValue("a" astAssignMul 1)
-        tester.parse("a %= 1").isChain(2, 1).isValue("a" astAssignMod 1)
-        tester.parse("a /= 1").isChain(2, 1).isValue("a" astAssignDiv 1)
-        tester.parse("val foo = 0").isChain(3, 1).isValue(astVarOf("foo", 0))
+        tester.parse("a = 1").isChain(1, 1, 1).isValue("a" astAssign 1)
+        tester.parse("a += 1").isChain(1, 1, 1).isValue("a" astAssignAdd 1)
+        tester.parse("a -= 1").isChain(1, 1, 1).isValue("a" astAssignSub 1)
+        tester.parse("a *= 1").isChain(1, 1, 1).isValue("a" astAssignMul 1)
+        tester.parse("a %= 1").isChain(1, 1, 1).isValue("a" astAssignMod 1)
+        tester.parse("a /= 1").isChain(1, 1, 1).isValue("a" astAssignDiv 1)
+        tester.parse("val foo = 0").isChain(0, 3, 1).isValue(astVarOf("foo", 0))
         
         // Control flow
-        tester.parse("if 1 a = 2").isWip(4).isOk(1).isDone()
+        tester.parse("if 1 a = 2").isWip(2).isOk(1).isWip(1).isOk(1).isDone()
             .isValue(astIfOf(1, success = listOf("a" astAssign 2)))
-        tester.parse("if 1 {} else a = 2").isWip(3).isOk(1).isWip(3).isOk(1).isDone()
+        tester.parse("if 1 {} else a = 2").isWip(3).isOk(1).isWip(1).isOk(1).isWip(1).isOk(1).isDone()
             .isValue(astIfOf(1, success = emptyList(), failure = listOf("a" astAssign 2)))
         
-        tester.parse("raise 1").isChain(1, 1).isValue(1.astReturnError)
-        tester.parse("return 1").isChain(1, 1).isValue(1.astReturnValue)
-        tester.parse("return _").isChain(1, 1).isValue(AstReturn)
+        tester.parse("raise 1").isChain(0, 1, 1).isValue(1.astReturnError)
+        tester.parse("return 1").isChain(0, 1, 1).isValue(1.astReturnValue)
+        tester.parse("return _").isChain(0, 1, 1).isValue(AstReturn)
         
         // Function call
-        tester.parse("a()").isChain(2, 1).isValue(astInvokeOf("a".astLoad().astCall()))
+        tester.parse("a()").isChain(1, 1, 1).isValue(astInvokeOf("a".astLoad().astCall()))
     }
     
     @Test
     fun `Given invalid token, when parsing, then correct error`()
     {
         tester.parse("").isBad { ParseError.UnexpectedToken(EndOfFile) }
-        tester.parse("a =").isWip(2).isBad { ParseError.UnexpectedToken(EndOfFile) }
+        tester.parse("a =").isOk(1).isWip(1).isBad { ParseError.UnexpectedToken(EndOfFile) }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverInstructions.kt
@@ -117,7 +117,7 @@ class TestResolverInstruction
         {
             val function = registerFun("fun")
             
-            assertSuccess(function.thirCall().thirEval, run(function.hirCall().hirEval))
+            assertSuccess(function.thirCall().thirEval, run(function.hirLoad().hirCall().hirEval))
         }
     }
     

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverSymbols.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverSymbols.kt
@@ -354,7 +354,7 @@ class TestResolverSymbol
         {
             val function = hirFunOf(value = null).also { scope.register(it) }
             
-            val input = hirVarOf(value = function.hirCall())
+            val input = hirVarOf(value = function.hirLoad().hirCall())
             val expected = TypeMissing(input.name, input.value)
             
             assertFailure(expected, run(input))

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.typechecker
 
+import com.github.derg.transpiler.phases.resolver.*
 import com.github.derg.transpiler.phases.typechecker.TypeError.*
 import com.github.derg.transpiler.source.hir.*
 import com.github.derg.transpiler.source.thir.*
@@ -8,14 +9,15 @@ import org.junit.jupiter.api.*
 
 class TestCheckerInstructions
 {
+    private val symbols = SymbolTable()
     private val bool = thirTypeData(Builtin.BOOL.id)
     private val int32 = thirTypeData(Builtin.INT32.id)
     
     @Nested
     inner class Assign
     {
-        private val checker = CheckerInstruction(value = bool, error = null)
-        private val variable = thirVarOf(type = bool)
+        private val checker = CheckerInstruction(symbols = symbols, value = null, error = null)
+        private val variable = thirVarOf(type = bool).also { symbols.variables[it.id] = it }
         
         @Test
         fun `Given valid type, when checking, then correct outcome`()
@@ -71,7 +73,7 @@ class TestCheckerInstructions
     @Nested
     inner class Branch
     {
-        private val checker = CheckerInstruction(value = null, error = null)
+        private val checker = CheckerInstruction(symbols = symbols, value = null, error = null)
         
         @Test
         fun `Given valid type, when checking, then correct outcome`()
@@ -127,7 +129,7 @@ class TestCheckerInstructions
     @Nested
     inner class Evaluate
     {
-        private val checker = CheckerInstruction(value = null, error = null)
+        private val checker = CheckerInstruction(symbols = symbols, value = null, error = null)
         
         @Test
         fun `Given no type, when checking, then correct outcome`()
@@ -175,9 +177,9 @@ class TestCheckerInstructions
     @Nested
     inner class Return
     {
-        private val checkerEmpty = CheckerInstruction(value = null, error = null)
-        private val checkerValue = CheckerInstruction(value = bool, error = null)
-        private val checkerError = CheckerInstruction(value = null, error = bool)
+        private val checkerEmpty = CheckerInstruction(symbols = symbols, value = null, error = null)
+        private val checkerValue = CheckerInstruction(symbols = symbols, value = bool, error = null)
+        private val checkerError = CheckerInstruction(symbols = symbols, value = null, error = bool)
         
         @Test
         fun `Given no type, when checking, then correct outcome`()
@@ -201,8 +203,8 @@ class TestCheckerInstructions
     @Nested
     inner class ReturnValue
     {
-        private val checkerEmpty = CheckerInstruction(value = null, error = null)
-        private val checkerValue = CheckerInstruction(value = bool, error = null)
+        private val checkerEmpty = CheckerInstruction(symbols = symbols, value = null, error = null)
+        private val checkerValue = CheckerInstruction(symbols = symbols, value = bool, error = null)
         
         @Test
         fun `Given valid type, when checking, then correct outcome`()
@@ -266,8 +268,8 @@ class TestCheckerInstructions
     @Nested
     inner class ReturnError
     {
-        private val checkerEmpty = CheckerInstruction(value = null, error = null)
-        private val checkerError = CheckerInstruction(value = null, error = bool)
+        private val checkerEmpty = CheckerInstruction(symbols = symbols, value = null, error = null)
+        private val checkerError = CheckerInstruction(symbols = symbols, value = null, error = bool)
         
         @Test
         fun `Given valid type, when checking, then correct outcome`()

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -66,6 +66,7 @@ infix fun Any.astCatchHandle(that: Any) = AstCatch(this.ast, that.ast, Capture.H
 
 fun String.astLoad(vararg parameters: Any) = AstLoad(this, parameters.map { it.astArg })
 fun AstValue.astCall(vararg parameters: Any) = AstCall(this, parameters.map { it.astArg })
+fun AstValue.astMember(field: String) = AstMember(this, field.astLoad())
 
 val Any.astArg: NamedMaybe<AstValue>
     get() = if (this is Pair<*, *>) (first as String) to (second as Any).ast else null to ast

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -82,15 +82,16 @@ infix fun Any.hirCatchRaise(that: Any) = HirCatch(this.hir, that.hir, Capture.RA
 infix fun Any.hirCatchReturn(that: Any) = HirCatch(this.hir, that.hir, Capture.RETURN)
 infix fun Any.hirCatchHandle(that: Any) = HirCatch(this.hir, that.hir, Capture.HANDLE)
 
-val HirSymbol.hirLoad: HirValue get() = HirLoad(name, emptyList())
-fun HirFunction.hirCall(vararg parameters: Any) = HirCall(hirLoad, parameters.map { null hirArg it })
+fun HirSymbol.hirLoad(vararg parameters: Any) = HirLoad(name, parameters.map { null hirArg it })
+fun HirValue.hirCall(vararg parameters: Any) = HirCall(this, parameters.map { null hirArg it })
+fun HirValue.hirMember(field: HirLoad) = HirMember(this, field)
 infix fun String?.hirArg(that: Any) = NamedMaybe(this, that.hir)
 
 ///////////////////////
 // Statement helpers //
 ///////////////////////
 
-infix fun HirVariable.hirAssign(that: Any) = HirAssign(hirLoad, that.hir)
+infix fun HirVariable.hirAssign(that: Any) = HirAssign(this.hirLoad(), that.hir)
 
 val Any.hirEval get() = HirEvaluate(hir)
 val Any.hirReturnError get() = HirReturnError(hir)


### PR DESCRIPTION
This pull request implements field accesses in the AST node. In order to support this feature in a more reasonable manner, the expression parser has been refactored, also fixing a few other issues which existed. Now, the expression parser is capable of handling arbitrarily nested function calls, and is better equipped for handling future expansions in the binary operators.