### PR TITLE
Fix issue where early returns were not respected

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/Main.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/Main.kt
@@ -26,16 +26,12 @@ private const val SOURCE = """
     
     fun fibonacci(n: __builtin_i32) -> __builtin_i32
     {
-        var result = 0
-
         if n <= 0
-            result = 0
+            return 0
         else if n == 1 || n == 2
-            result = 1
+            return 1
         else
-            result = fibonacci(n - 2) + fibonacci(n - 1)
-
-        return result
+            return fibonacci(n - 2) + fibonacci(n - 1)
     }
 """
 


### PR DESCRIPTION
This pull request fixes an annoyance where it was not possible to return from functions from within a branch. This forced some rather unpleasant code, where the result value had to be updated from within the branches, then returning the value at the end. Instead, the code is cleaner and simpler when early returns are possible.