### PR TITLE
51 implement parsing of loops

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
@@ -61,6 +61,7 @@ class Interpreter(private val symbols: SymbolTable)
             is ThirReturn      -> return Evaluation(null.toSuccess(), true)
             is ThirReturnError -> return Evaluation(evaluateExpression(frame, instruction.expression).toFailure(), true)
             is ThirReturnValue -> return Evaluation(evaluateExpression(frame, instruction.expression).toSuccess(), true)
+            is ThirWhile       -> TODO()
         }
         return Evaluation(null.toSuccess(), false)
     }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -190,6 +190,7 @@ internal fun AstInstruction.toHir(): HirInstruction = when (this)
     is AstAssignAdd      -> HirAssignAdd(HirLoad(name, emptyList()), expression.toHir())
     is AstBranch         -> HirBranch(predicate.toHir(), success.map { it.toHir() }, failure.map { it.toHir() })
     is AstEvaluate       -> HirEvaluate(expression.toHir())
+    is AstFor            -> TODO()
     is AstReturn         -> HirReturn
     is AstReturnError    -> HirReturnError(expression.toHir())
     is AstReturnValue    -> HirReturnValue(expression.toHir())

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -190,10 +190,10 @@ internal fun AstInstruction.toHir(): HirInstruction = when (this)
     is AstAssignAdd      -> HirAssignAdd(HirLoad(name, emptyList()), expression.toHir())
     is AstBranch         -> HirBranch(predicate.toHir(), success.map { it.toHir() }, failure.map { it.toHir() })
     is AstEvaluate       -> HirEvaluate(expression.toHir())
-    is AstFor            -> TODO()
+    is AstFor            -> HirFor(identifier, expression.toHir(), instructions.map { it.toHir() })
     is AstReturn         -> HirReturn
     is AstReturnError    -> HirReturnError(expression.toHir())
     is AstReturnValue    -> HirReturnValue(expression.toHir())
     is AstVariable       -> HirAssign(HirLoad(name, emptyList()), value.toHir())
-    is AstWhile          -> TODO()
+    is AstWhile          -> HirWhile(predicate.toHir(), instructions.map { it.toHir() })
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/converter/Converter.kt
@@ -195,4 +195,5 @@ internal fun AstInstruction.toHir(): HirInstruction = when (this)
     is AstReturnError    -> HirReturnError(expression.toHir())
     is AstReturnValue    -> HirReturnValue(expression.toHir())
     is AstVariable       -> HirAssign(HirLoad(name, emptyList()), value.toHir())
+    is AstWhile          -> TODO()
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserInstructions.kt
@@ -25,6 +25,7 @@ fun statementParserOf(): Parser<AstInstruction> = ParserAnyOf(
     assignmentParserOf(),
     branchParserOf(),
     invokeParserOf(),
+    forParserOf(),
     raiseParserOf(),
     returnParserOf(),
 )
@@ -72,6 +73,23 @@ private fun branchElsePatternOf() =
 
 private fun branchElseOutcomeOf(values: Parsers): List<AstInstruction> =
     values["scope"]
+
+/**
+ * Parses a for loop from the token stream.
+ */
+private fun forParserOf(): Parser<AstInstruction> =
+    ParserPattern(::forPatternOf, ::forOutcomeOf)
+
+private fun forPatternOf() = ParserSequence(
+    "for" to ParserSymbol(Symbol.FOR),
+    "identifier" to ParserIdentifier(),
+    "in" to ParserSymbol(Symbol.IN),
+    "expression" to ParserExpression(),
+    "scope" to scopeParserOf(),
+)
+
+private fun forOutcomeOf(values: Parsers): AstFor =
+    AstFor(values["identifier"], values["expression"], values["scope"])
 
 /**
  * Parses a single raise control flow from the token stream.

--- a/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/parser/ParserInstructions.kt
@@ -28,6 +28,7 @@ fun statementParserOf(): Parser<AstInstruction> = ParserAnyOf(
     forParserOf(),
     raiseParserOf(),
     returnParserOf(),
+    whileParserOf(),
 )
 
 /**
@@ -122,6 +123,21 @@ private fun returnOutcomeOf(values: Parsers): AstInstruction
     // TODO: The magic string `_` should not be used. Use the type-information of the function to remove it
     return if (expression == AstLoad("_", emptyList())) AstReturn else AstReturnValue(expression)
 }
+
+/**
+ * Parses a while loop from the token stream.
+ */
+private fun whileParserOf(): Parser<AstInstruction> =
+    ParserPattern(::whilePatternOf, ::whileOutcomeOf)
+
+private fun whilePatternOf() = ParserSequence(
+    "while" to ParserSymbol(Symbol.WHILE),
+    "expression" to ParserExpression(),
+    "scope" to scopeParserOf(),
+)
+
+private fun whileOutcomeOf(values: Parsers): AstWhile =
+    AstWhile(values["expression"], values["scope"])
 
 /**
  * Parses a single expression statement from the token stream. Note that the parser does not implement analysis to

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/ResolverInstructions.kt
@@ -31,9 +31,11 @@ internal class ResolverInstruction(symbols: SymbolTable, private val types: Type
         is HirAssignAdd      -> TODO()
         is HirBranch         -> handle(node)
         is HirEvaluate       -> handle(node)
+        is HirFor            -> TODO()
         is HirReturn         -> ThirReturn.toSuccess()
         is HirReturnError    -> values.resolve(node.expression).mapValue { ThirReturnError(it) }
         is HirReturnValue    -> values.resolve(node.expression).mapValue { ThirReturnValue(it) }
+        is HirWhile          -> handle(node)
     }
     
     private fun handle(node: HirAssign): Result<ThirInstruction, ResolveError>
@@ -69,5 +71,13 @@ internal class ResolverInstruction(symbols: SymbolTable, private val types: Type
         val expression = values.resolve(node.expression).valueOr { return it.toFailure() }
         
         return ThirEvaluate(expression).toSuccess()
+    }
+    
+    private fun handle(node: HirWhile): Result<ThirInstruction, ResolveError>
+    {
+        val predicate = values.resolve(node.predicate).valueOr { return it.toFailure() }
+        val instructions = node.instructions.mapUntilError { resolve(it) }.valueOr { return it.toFailure() }
+        
+        return ThirWhile(predicate, instructions).toSuccess()
     }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/Checker.kt
@@ -120,4 +120,19 @@ sealed interface TypeError
      * The return statement has an [expression] which evaluates to an error, when no return error was expected.
      */
     data class ReturnContainsError(val expression: ThirValue) : TypeError
+    
+    /**
+     * The while loop [predicate] evaluates to no type at all.
+     */
+    data class WhileMissingValue(val predicate: ThirValue) : TypeError
+    
+    /**
+     * The while loop [predicate] did not evaluate to a boolean type, which is required by the loop predicate.
+     */
+    data class WhileWrongType(val predicate: ThirValue) : TypeError
+    
+    /**
+     * The while loop [predicate] is evaluated to a possible error type, which is not permitted.
+     */
+    data class WhileContainsError(val predicate: ThirValue) : TypeError
 }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -22,6 +22,7 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         is ThirReturn      -> handle(node)
         is ThirReturnError -> handle(node)
         is ThirReturnValue -> handle(node)
+        is ThirWhile       -> TODO()
     }
     
     private fun handle(node: ThirAssign): Result<Unit, TypeError>

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerInstructions.kt
@@ -22,7 +22,7 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         is ThirReturn      -> handle(node)
         is ThirReturnError -> handle(node)
         is ThirReturnValue -> handle(node)
-        is ThirWhile       -> TODO()
+        is ThirWhile       -> handle(node)
     }
     
     private fun handle(node: ThirAssign): Result<Unit, TypeError>
@@ -40,7 +40,7 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         val value = symbols.variables[node.symbolId]?.type
         if (value != node.expression.value)
             return TypeError.AssignWrongType(node.expression).toFailure()
-    
+        
         return CheckerValue().check(node.expression)
     }
     
@@ -54,7 +54,7 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         val value = node.predicate.value ?: return TypeError.BranchMissingValue(node.predicate).toFailure()
         if (value !is ThirType.Structure || value.symbolId != Builtin.BOOL.id)
             return TypeError.BranchWrongType(node.predicate).toFailure()
-    
+        
         return CheckerValue().check(node.predicate)
     }
     
@@ -67,7 +67,7 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         // Evaluations are not permitted to contain value types.
         if (node.expression.value != null)
             return TypeError.EvaluateContainsValue(node.expression).toFailure()
-    
+        
         return CheckerValue().check(node.expression)
     }
     
@@ -98,7 +98,7 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         // TODO: Support union types.
         if (value != node.expression.value)
             return TypeError.ReturnWrongType(node.expression).toFailure()
-    
+        
         return CheckerValue().check(node.expression)
     }
     
@@ -120,7 +120,21 @@ internal class CheckerInstruction(private val symbols: SymbolTable, private val 
         // TODO: Support union types.
         if (error != node.expression.value)
             return TypeError.ReturnWrongType(node.expression).toFailure()
-    
+        
         return CheckerValue().check(node.expression)
+    }
+    
+    private fun handle(node: ThirWhile): Result<Unit, TypeError>
+    {
+        // Predicates are not permitted to contain error types.
+        if (node.predicate.error != null)
+            return TypeError.WhileContainsError(node.predicate).toFailure()
+        
+        // The value type must be boolean.
+        val value = node.predicate.value ?: return TypeError.WhileMissingValue(node.predicate).toFailure()
+        if (value !is ThirType.Structure || value.symbolId != Builtin.BOOL.id)
+            return TypeError.WhileWrongType(node.predicate).toFailure()
+        
+        return CheckerValue().check(node.predicate)
     }
 }

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Instructions.kt
@@ -65,3 +65,9 @@ data class AstReturnError(val expression: AstValue) : AstInstruction
  * value from a function indicates usually that the function has succeeded in producing a usable value.
  */
 data class AstReturnValue(val expression: AstValue) : AstInstruction
+
+/**
+ * While loops are a control flow construct which iterates until the [predicate] evaluates to false. The [instructions]
+ * will be repeatedly executed until no more elements remains in the loop.
+ */
+data class AstWhile(val predicate: AstValue, val instructions: List<AstInstruction>) : AstInstruction

--- a/src/main/kotlin/com/github/derg/transpiler/source/ast/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/ast/Instructions.kt
@@ -39,6 +39,13 @@ data class AstBranch(val predicate: AstValue, val success: List<AstInstruction>,
 data class AstEvaluate(val expression: AstValue) : AstInstruction
 
 /**
+ * For loops are a control flow construct which iterates over the [expression] until all elements in the expression has
+ * been looped over. The [identifier] denotes the name of the variable which holds the current element in the loop. The
+ * [instructions] will be repeatedly executed until no more elements remains in the loop.
+ */
+data class AstFor(val identifier: String, val expression: AstValue, val instructions: List<AstInstruction>) : AstInstruction
+
+/**
  * Specifies that the execution flow should exit the current function, returning control flow back to the caller. Note
  * that the function cannot be exited in this manner if the function expects a return value.
  */

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Instructions.kt
@@ -33,6 +33,13 @@ data class HirBranch(
 data class HirEvaluate(val expression: HirValue) : HirInstruction
 
 /**
+ * Loops are a control flow construct which iterates over the [expression] until all elements in the expression has been
+ * looped over. The [identifier] denotes the name of the variable which holds the current element in the loop. The
+ * [instructions] will be repeatedly executed until no more elements remains in the loop.
+ */
+data class HirFor(val identifier: String, val expression: HirValue, val instructions: List<HirInstruction>) : HirInstruction
+
+/**
  * Exist the current function call, returning control flow to whoever called the function in the first place.
  */
 data object HirReturn : HirInstruction
@@ -48,3 +55,9 @@ data class HirReturnError(val expression: HirValue) : HirInstruction
  * return value of the function is provided by the given [expression].
  */
 data class HirReturnValue(val expression: HirValue) : HirInstruction
+
+/**
+ * While loops are a control flow construct which iterates until the [predicate] evaluates to false. The [instructions]
+ * will be repeatedly executed until no more elements remains in the loop.
+ */
+data class HirWhile(val predicate: HirValue, val instructions: List<HirInstruction>) : HirInstruction

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Instructions.kt
@@ -45,3 +45,9 @@ data class ThirReturnError(val expression: ThirValue) : ThirInstruction
  * return value of the function is provided by the given [expression].
  */
 data class ThirReturnValue(val expression: ThirValue) : ThirInstruction
+
+/**
+ * While loops are a control flow construct which iterates until the [predicate] evaluates to false. The [instructions]
+ * will be repeatedly executed until no more elements remains in the loop.
+ */
+data class ThirWhile(val predicate: ThirValue, val instructions: List<ThirInstruction>) : ThirInstruction

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserInstructions.kt
@@ -36,6 +36,8 @@ class TestParserInstructions
         
         tester.parse("for a in b {}").isChain(0, 5, 1).isValue(astForOf("a", "b".astLoad(), emptyList()))
         tester.parse("for a in b 0").isChain(0, 4, 1).isValue(astForOf("a", "b".astLoad(), listOf(0.astEval)))
+        tester.parse("while a {}").isChain(0, 3, 1).isValue(astWhileOf("a".astLoad(), emptyList()))
+        tester.parse("while a 0").isChain(0, 2, 1).isValue(astWhileOf("a".astLoad(), listOf(0.astEval)))
         
         tester.parse("raise 1").isChain(0, 1, 1).isValue(1.astReturnError)
         tester.parse("return 1").isChain(0, 1, 1).isValue(1.astReturnValue)

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserInstructions.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.*
 private fun <Type> Tester<Type>.isChain(preOkCount: Int = 0, wipCount: Int = 0, postOkCount: Int = 0): Tester<Type> =
     isOk(preOkCount).isWip(wipCount).isOk(postOkCount).isDone()
 
-class TestParserStatement
+class TestParserInstructions
 {
     private val tester = Tester { statementParserOf() }
     
@@ -33,6 +33,9 @@ class TestParserStatement
             .isValue(astIfOf(1, success = listOf("a" astAssign 2)))
         tester.parse("if 1 {} else a = 2").isWip(3).isOk(1).isWip(1).isOk(1).isWip(1).isOk(1).isDone()
             .isValue(astIfOf(1, success = emptyList(), failure = listOf("a" astAssign 2)))
+        
+        tester.parse("for a in b {}").isChain(0, 5, 1).isValue(astForOf("a", "b".astLoad(), emptyList()))
+        tester.parse("for a in b 0").isChain(0, 4, 1).isValue(astForOf("a", "b".astLoad(), listOf(0.astEval)))
         
         tester.parse("raise 1").isChain(0, 1, 1).isValue(1.astReturnError)
         tester.parse("return 1").isChain(0, 1, 1).isValue(1.astReturnValue)

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverInstructions.kt
@@ -142,4 +142,20 @@ class TestResolverInstruction
             assertSuccess(1.thirReturnError, run(1.hirReturnError))
         }
     }
+    
+    @Nested
+    inner class While
+    {
+        @Test
+        fun `Given valid predicate, when resolving, then correct outcome`()
+        {
+            assertSuccess(true.thirWhile(), run(true.hirWhile()))
+        }
+        
+        @Test
+        fun `Given instructions, when resolving, then correct outcome`()
+        {
+            assertSuccess(false.thirWhile(ThirReturn), run(false.hirWhile(HirReturn)))
+        }
+    }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/typechecker/TestCheckerInstructions.kt
@@ -50,7 +50,7 @@ class TestCheckerInstructions
             
             assertFailure(AssignMissingValue(input), checker.check(variable.thirAssign(input)))
         }
-    
+        
         @Test
         fun `Given valid value, when checking, then correct outcome`()
         {
@@ -65,7 +65,7 @@ class TestCheckerInstructions
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-    
+            
             assertFailure(CallContainsError(instance), checker.check(variable.thirAssign(input)))
         }
     }
@@ -106,22 +106,22 @@ class TestCheckerInstructions
             
             assertFailure(BranchMissingValue(input), checker.check(input.thirBranch()))
         }
-    
+        
         @Test
         fun `Given valid value, when checking, then correct outcome`()
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = null).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-        
+            
             assertSuccess(Unit, checker.check(input.thirBranch()))
         }
-    
+        
         @Test
         fun `Given invalid value, when checking, then correct error`()
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-        
+            
             assertFailure(CallContainsError(instance), checker.check(input.thirBranch()))
         }
     }
@@ -154,22 +154,22 @@ class TestCheckerInstructions
             
             assertFailure(EvaluateContainsError(input), checker.check(input.thirEval))
         }
-    
+        
         @Test
         fun `Given valid value, when checking, then correct outcome`()
         {
             val instance = thirFunOf(value = thirTypeFun(), error = null).thirCall()
             val input = instance.thirCall(value = null, error = null)
-        
+            
             assertSuccess(Unit, checker.check(input.thirEval))
         }
-    
+        
         @Test
         fun `Given invalid value, when checking, then correct error`()
         {
             val instance = thirFunOf(value = thirTypeFun(), error = int32).thirCall()
             val input = instance.thirCall(value = null, error = null)
-        
+            
             assertFailure(CallContainsError(instance), checker.check(input.thirEval))
         }
     }
@@ -245,22 +245,22 @@ class TestCheckerInstructions
             
             assertFailure(ReturnContainsValue(input), checkerEmpty.check(input.thirReturnValue))
         }
-    
+        
         @Test
         fun `Given valid value, when checking, then correct outcome`()
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = null).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-        
+            
             assertSuccess(Unit, checkerValue.check(input.thirReturnValue))
         }
-    
+        
         @Test
         fun `Given invalid value, when checking, then correct error`()
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-        
+            
             assertFailure(CallContainsError(instance), checkerValue.check(input.thirReturnValue))
         }
     }
@@ -310,23 +310,79 @@ class TestCheckerInstructions
             
             assertFailure(ReturnContainsValue(input), checkerEmpty.check(input.thirReturnError))
         }
-    
+        
         @Test
         fun `Given valid value, when checking, then correct outcome`()
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = null).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-        
+            
             assertSuccess(Unit, checkerError.check(input.thirReturnError))
         }
-    
+        
         @Test
         fun `Given invalid value, when checking, then correct error`()
         {
             val instance = thirFunOf(value = thirTypeFun(bool), error = int32).thirCall()
             val input = instance.thirCall(value = bool, error = null)
-        
+            
             assertFailure(CallContainsError(instance), checkerError.check(input.thirReturnError))
+        }
+    }
+    
+    @Nested
+    inner class While
+    {
+        private val checker = CheckerInstruction(symbols = symbols, value = null, error = null)
+        
+        @Test
+        fun `Given valid type, when checking, then correct outcome`()
+        {
+            val input = thirFunOf(value = bool).thirCall()
+            
+            assertSuccess(Unit, checker.check(input.thirWhile()))
+        }
+        
+        @Test
+        fun `Given invalid type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = thirTypeStruct()).thirCall()
+            
+            assertFailure(WhileWrongType(input), checker.check(input.thirWhile()))
+        }
+        
+        @Test
+        fun `Given error type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = bool, error = bool).thirCall()
+            
+            assertFailure(WhileContainsError(input), checker.check(input.thirWhile()))
+        }
+        
+        @Test
+        fun `Given no type, when checking, then correct error`()
+        {
+            val input = thirFunOf(value = null).thirCall()
+            
+            assertFailure(WhileMissingValue(input), checker.check(input.thirWhile()))
+        }
+        
+        @Test
+        fun `Given valid value, when checking, then correct outcome`()
+        {
+            val instance = thirFunOf(value = thirTypeFun(bool), error = null).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+            
+            assertSuccess(Unit, checker.check(input.thirWhile()))
+        }
+        
+        @Test
+        fun `Given invalid value, when checking, then correct error`()
+        {
+            val instance = thirFunOf(value = thirTypeFun(bool), error = int32).thirCall()
+            val input = instance.thirCall(value = bool, error = null)
+            
+            assertFailure(CallContainsError(instance), checker.check(input.thirWhile()))
         }
     }
 }

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -94,7 +94,7 @@ infix fun String.astAssignDiv(that: Any) = AstAssignDivide(this, that.ast)
 
 val Any.astReturnError get() = AstReturnError(ast)
 val Any.astReturnValue get() = AstReturnValue(ast)
-val AstValue.astEval get() = AstEvaluate(this)
+val Any.astEval get() = AstEvaluate(ast)
 
 fun astInvokeOf(expression: Any) = AstEvaluate(expression.ast)
 
@@ -120,7 +120,16 @@ fun astIfOf(predicate: Any, success: List<AstInstruction>, failure: List<AstInst
     AstBranch(predicate.ast, success, failure)
 
 /**
- * Generates a branch expression from the provided input parameters.
+ * Generates a for loop statement from the provided input parameters.
+ */
+fun astForOf(
+    identifier: String = UUID.randomUUID().toString(),
+    expression: Any,
+    instructions: List<AstInstruction> = emptyList(),
+) = AstFor(identifier, expression.ast, instructions)
+
+/**
+ * Generates a when expression from the provided input parameters.
  */
 fun astWhenOf(expression: Any, vararg branches: Pair<Any, Any>, default: Any? = null) =
     AstWhen(expression.ast, branches.map { it.first.ast to it.second.ast }, default?.ast)

--- a/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/ast/Helpers.kt
@@ -134,6 +134,14 @@ fun astForOf(
 fun astWhenOf(expression: Any, vararg branches: Pair<Any, Any>, default: Any? = null) =
     AstWhen(expression.ast, branches.map { it.first.ast to it.second.ast }, default?.ast)
 
+/**
+ * Generates a while loop statement from the provided input parameters.
+ */
+fun astWhileOf(
+    expression: Any,
+    instructions: List<AstInstruction> = emptyList(),
+) = AstWhile(expression.ast, instructions)
+
 ////////////////////
 // Symbol helpers //
 ////////////////////

--- a/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/hir/Helpers.kt
@@ -112,6 +112,8 @@ fun Any.hirBranch(
     failure: List<HirInstruction> = emptyList(),
 ) = HirBranch(hir, success, failure)
 
+fun Any.hirWhile(vararg instructions: HirInstruction) = HirWhile(hir, instructions.toList())
+
 ////////////////////
 // Symbol helpers //
 ////////////////////

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -143,6 +143,8 @@ fun Any.thirBranch(
     failure: List<ThirInstruction> = emptyList(),
 ) = ThirBranch(thir, success, failure)
 
+fun Any.thirWhile(vararg instructions: ThirInstruction) = ThirWhile(thir, instructions.toList())
+
 ////////////////////
 // Symbol helpers //
 ////////////////////


### PR DESCRIPTION
This pull request adds in parsing of basic loop constructs such as the `for` and `while` loops. While the usability of for loops is considerably limited in this implementation, the while loop is implemented fully. A user can now write a program containing while loops, which expects exactly a boolean predicate. The while loop can contain any number of statements, and will be executed for as long as the predicate holds true.