### PR TITLE
Add basic version of string data type

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/interpreter/Interpreter.kt
@@ -81,6 +81,7 @@ class Interpreter(private val symbols: SymbolTable)
         is ThirConstBool  -> value
         is ThirConstInt32 -> value
         is ThirConstInt64 -> value
+        is ThirConstStr   -> value
         is ThirLoad       -> frame[value.symbolId]
         is ThirMember     -> (evaluateExpression(frame, value.instance) as ThirRecord).fields[value.fieldId]!!
         is ThirRecord     -> value.apply { fields.forEach { (id, value) -> fields[id] = evaluateExpression(frame, value) } }
@@ -130,6 +131,9 @@ class Interpreter(private val symbols: SymbolTable)
             Builtin.INT64_NEG.id -> ThirConstInt64(-(a as ThirConstInt64).raw)
             Builtin.INT64_POS.id -> ThirConstInt64((a as ThirConstInt64).raw)
             Builtin.INT64_SUB.id -> ThirConstInt64((a as ThirConstInt64).raw - (b as ThirConstInt64).raw)
+            Builtin.STR_EQ.id    -> ThirConstBool((a as ThirConstStr).raw == (b as ThirConstStr).raw)
+            Builtin.STR_NE.id    -> ThirConstBool((a as ThirConstStr).raw != (b as ThirConstStr).raw)
+            Builtin.STR_ADD.id   -> ThirConstStr((a as ThirConstStr).raw + (b as ThirConstStr).raw)
             else                 -> pushFrame { evaluate(it, symbol, parameters).outcome.valueOrNull() ?: TODO() }
         }
     }

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/Resolver.kt
@@ -111,6 +111,11 @@ sealed interface ResolveError
     data class InvalidLiteralInteger(val value: BigInteger) : ResolveError
     
     /**
+     * The literal with the given [value] is outside the allowed dynamic range.
+     */
+    data class InvalidLiteralString(val value: String) : ResolveError
+    
+    /**
      * Used to represent an error which is not yet defined.
      */
     data object Placeholder : ResolveError

--- a/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/typechecker/CheckerValues.kt
@@ -22,6 +22,7 @@ internal class CheckerValue
         is ThirConstBool  -> Unit.toSuccess()
         is ThirConstInt32 -> Unit.toSuccess()
         is ThirConstInt64 -> Unit.toSuccess()
+        is ThirConstStr   -> Unit.toSuccess()
     }
     
     private fun handle(node: ThirCall): Result<Unit, TypeError>

--- a/src/main/kotlin/com/github/derg/transpiler/source/Constants.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/Constants.kt
@@ -13,7 +13,6 @@ const val STR_LIT_NAME = "s"
  * into the compiler. These data structures cannot be represented in source code as libraries without great effort and
  * poor support.
  */
-const val VOID_TYPE_NAME = "__builtin_void"
 const val BOOL_TYPE_NAME = "__builtin_bool"
 const val INT32_TYPE_NAME = "__builtin_i32"
 const val INT64_TYPE_NAME = "__builtin_i64"

--- a/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/hir/Builtin.kt
@@ -63,10 +63,12 @@ object Builtin
     val INT64_POS = registerPrefixOp(Symbol.PLUS, INT64_TYPE, INT64_TYPE, null)
     val INT64_SUB = registerInfixOp(Symbol.MINUS, INT64_TYPE, INT64_TYPE, null)
     
-    // TODO: Support strings somehow
     val STR = registerStruct(STR_TYPE_NAME)
     val STR_TYPE = typeOf(STR)
     val STR_LIT = registerLiteral(STR_LIT_NAME, STR_TYPE)
+    val STR_EQ = registerInfixOp(Symbol.EQUAL, STR_TYPE, BOOL_TYPE, null)
+    val STR_NE = registerInfixOp(Symbol.NOT_EQUAL, STR_TYPE, BOOL_TYPE, null)
+    val STR_ADD = registerInfixOp(Symbol.PLUS, STR_TYPE, STR_TYPE, null)
 }
 
 /**

--- a/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/source/thir/Values.kt
@@ -99,3 +99,12 @@ data class ThirConstInt64(val raw: Long) : ThirValue
     override val value: ThirType get() = ThirType.Structure(Builtin.INT64.id, Mutability.IMMUTABLE, emptyList())
     override val error: Nothing? get() = null
 }
+
+/**
+ * Unicode character sequences.
+ */
+data class ThirConstStr(val raw: String) : ThirValue
+{
+    override val value: ThirType get() = ThirType.Structure(Builtin.STR.id, Mutability.IMMUTABLE, emptyList())
+    override val error: Nothing? get() = null
+}

--- a/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/parser/TestParserValues.kt
@@ -1,5 +1,6 @@
 package com.github.derg.transpiler.phases.parser
 
+import com.github.derg.transpiler.source.*
 import com.github.derg.transpiler.source.ast.*
 import com.github.derg.transpiler.source.lexeme.*
 import org.junit.jupiter.api.*

--- a/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/phases/resolver/TestResolverValues.kt
@@ -7,7 +7,6 @@ import com.github.derg.transpiler.source.thir.*
 import com.github.derg.transpiler.utils.*
 import org.junit.jupiter.api.*
 import java.math.*
-import java.util.*
 
 /**
  * Generates a thir-representation of the struct.
@@ -98,6 +97,7 @@ class TestResolverValue
         {
             assertSuccess(1 thirAdd 2, run(1 hirAdd 2))
             assertSuccess(1L thirAdd 2L, run(1L hirAdd 2L))
+            assertSuccess("a" thirAdd "b", run("a" hirAdd "b"))
         }
         
         @Test
@@ -295,6 +295,7 @@ class TestResolverValue
             assertSuccess(true thirEq false, run(true hirEq false))
             assertSuccess(1 thirEq 2, run(1 hirEq 2))
             assertSuccess(1L thirEq 2L, run(1L hirEq 2L))
+            assertSuccess("a" thirEq "b", run("a" hirEq "b"))
         }
         
         @Test
@@ -495,7 +496,7 @@ class TestResolverValue
             
             assertSuccess(expected, run(symbol.hirLoad()))
         }
-    
+        
         @Test
         fun `Given parameter, when resolving, then correct outcome`()
         {
@@ -646,6 +647,7 @@ class TestResolverValue
             assertSuccess(true thirNe false, run(true hirNe false))
             assertSuccess(1 thirNe 2, run(1 hirNe 2))
             assertSuccess(1L thirNe 2L, run(1L hirNe 2L))
+            assertSuccess("a" thirNe "b", run("a" hirNe "b"))
         }
         
         @Test
@@ -742,6 +744,46 @@ class TestResolverValue
             val expected = ArgumentMismatch(Symbol.MINUS.symbol, listOf(null hirArg true, null hirArg false))
             
             assertFailure(expected, run(true hirSub false))
+        }
+    }
+    
+    @Nested
+    inner class Text
+    {
+        @Test
+        fun `Given builtin types, when resolving, then correct outcome`()
+        {
+            assertSuccess("".thir, run("".hir))
+            assertSuccess("a".thir, run("a".hir))
+            assertSuccess("Hello World!".thir, run("Hello World!".hir))
+            assertSuccess("nøt vålid? bût it ïs!".thir, run("nøt vålid? bût it ïs!".hir))
+        }
+        
+        @Test
+        fun `Given known overload, when resolving, then correct outcome`()
+        {
+            val str = registerLit("foo", Builtin.STR_TYPE)
+            
+            assertSuccess(str.thirCall("b"), run(HirText("b", str.name)))
+        }
+        
+        @Test
+        fun `Given unknown overload, when resolving, then correct error`()
+        {
+            val value = HirText("whatever", "foo")
+            
+            assertFailure(UnknownLiteral("foo"), run(value))
+        }
+        
+        @Test
+        fun `Given ambiguous overload, when resolving, then correct error`()
+        {
+            registerLit("foo", Builtin.BOOL_TYPE)
+            registerLit("foo", Builtin.STR_TYPE)
+            
+            val value = HirText("whatever", "foo")
+            
+            assertFailure(AmbiguousLiteral("foo", value), run(value))
         }
     }
     

--- a/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
+++ b/src/test/kotlin/com/github/derg/transpiler/source/thir/Helpers.kt
@@ -15,6 +15,7 @@ val Any.thir: ThirValue
         is Boolean   -> ThirConstBool(this)
         is Int       -> ThirConstInt32(this)
         is Long      -> ThirConstInt64(this)
+        is String    -> ThirConstStr(this)
         else         -> throw IllegalArgumentException("Value $this does not represent a valid thir value")
     }
 
@@ -91,9 +92,11 @@ val Long.thirMinus get() = op(Builtin.INT64_NEG, Builtin.INT64, null, this.thir)
 infix fun Boolean.thirEq(that: Boolean) = op(Builtin.BOOL_EQ, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Int.thirEq(that: Int) = op(Builtin.INT32_EQ, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Long.thirEq(that: Long) = op(Builtin.INT64_EQ, Builtin.BOOL, null, this.thir, that.thir)
+infix fun String.thirEq(that: String) = op(Builtin.STR_EQ, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Boolean.thirNe(that: Boolean) = op(Builtin.BOOL_NE, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Int.thirNe(that: Int) = op(Builtin.INT32_NE, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Long.thirNe(that: Long) = op(Builtin.INT64_NE, Builtin.BOOL, null, this.thir, that.thir)
+infix fun String.thirNe(that: String) = op(Builtin.STR_NE, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Int.thirGe(that: Int) = op(Builtin.INT32_GE, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Long.thirGe(that: Long) = op(Builtin.INT64_GE, Builtin.BOOL, null, this.thir, that.thir)
 infix fun Int.thirGt(that: Int) = op(Builtin.INT32_GT, Builtin.BOOL, null, this.thir, that.thir)
@@ -105,6 +108,7 @@ infix fun Long.thirLt(that: Long) = op(Builtin.INT64_LT, Builtin.BOOL, null, thi
 
 infix fun Int.thirAdd(that: Int) = op(Builtin.INT32_ADD, Builtin.INT32, null, this.thir, that.thir)
 infix fun Long.thirAdd(that: Long) = op(Builtin.INT64_ADD, Builtin.INT64, null, this.thir, that.thir)
+infix fun String.thirAdd(that: String) = op(Builtin.STR_ADD, Builtin.STR, null, this.thir, that.thir)
 infix fun Int.thirSub(that: Int) = op(Builtin.INT32_SUB, Builtin.INT32, null, this.thir, that.thir)
 infix fun Long.thirSub(that: Long) = op(Builtin.INT64_SUB, Builtin.INT64, null, this.thir, that.thir)
 infix fun Int.thirMul(that: Int) = op(Builtin.INT32_MUL, Builtin.INT32, null, this.thir, that.thir)


### PR DESCRIPTION
In this pull request we introduce a super-rudimentary string type. There is next to no functionality on this string type, aside from equality and bare-bones operations. A user should be able to utilize this string for the most primitive debugging capabilities, to understand what is going on in a running program.