### PR TITLE
Fix variables local to if and while scopes

### DIFF
--- a/src/main/kotlin/com/github/derg/transpiler/Main.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/Main.kt
@@ -34,13 +34,57 @@ private const val PROGRAM = """
         val bar: __builtin_i32 = 23
     }
 
+    fun str(value: __builtin_i32) -> __builtin_str
+    {
+        var sign = ""
+        var string = ""
+        var current = value
+        
+        if current < 0
+        {
+            sign = "-"
+            current = -current
+        }
+        
+        while current > 0
+        {
+            val remainder = current % 10
+            
+            if remainder == 0
+                string = "0" + string
+            else if remainder == 1
+                string = "1" + string
+            else if remainder == 2
+                string = "2" + string
+            else if remainder == 3
+                string = "3" + string
+            else if remainder == 4
+                string = "4" + string
+            else if remainder == 5
+                string = "5" + string
+            else if remainder == 6
+                string = "6" + string
+            else if remainder == 7
+                string = "7" + string
+            else if remainder == 8
+                string = "8" + string
+            else if remainder == 9
+                string = "9" + string
+            
+            current = current / 10
+        }
+        
+        return sign + string
+    }
+    
     fun main() -> __builtin_i32
     {
         val test = Test(foo = 2)
+        val data = fibonacci(test.foo + test.bar)
 
-        __builtin_println("Hello World!")
-
-        return fibonacci(test.foo + test.bar)
+        __builtin_println("fibonacci(" + str(test.foo + test.bar) + ") = " + str(data))
+        
+        return data
     }
 """
 

--- a/src/main/kotlin/com/github/derg/transpiler/phases/resolver/workers/Statements.kt
+++ b/src/main/kotlin/com/github/derg/transpiler/phases/resolver/workers/Statements.kt
@@ -102,9 +102,11 @@ internal class IfDefiner(
     scope: Scope,
 ) : Worker<ThirStatement>
 {
+    private val innerScopeTrue = Scope(scope)
+    private val innerScopeFalse = Scope(scope)
     private val predicateWorker = expressionDefinerOf(evaluator, node.predicate, env, scope, ThirKind.Value(ThirType.Bool), false)
-    private val successWorker = WorkerList(node.success) { statementDefinerOf(evaluator, it, env, Scope(scope)) }
-    private val failureWorker = WorkerList(node.failure) { statementDefinerOf(evaluator, it, env, Scope(scope)) }
+    private val successWorker = WorkerList(node.success) { statementDefinerOf(evaluator, it, env, innerScopeTrue) }
+    private val failureWorker = WorkerList(node.failure) { statementDefinerOf(evaluator, it, env, innerScopeFalse) }
     
     private var predicate: ThirExpression? = null
     private var success: List<ThirStatement>? = null
@@ -228,8 +230,9 @@ internal class WhileDefiner(
     scope: Scope,
 ) : Worker<ThirStatement>
 {
+    private val innerScope = Scope(scope)
     private val predicateWorker = expressionDefinerOf(evaluator, node.predicate, env, scope, null, false)
-    private val statementsWorker = WorkerList(node.body) { statementDefinerOf(evaluator, it, env, Scope(scope)) }
+    private val statementsWorker = WorkerList(node.body) { statementDefinerOf(evaluator, it, env, innerScope) }
     
     private var predicate: ThirExpression? = null
     private var statements: List<ThirStatement>? = null


### PR DESCRIPTION
This pull request fixes an issue where variables declared in if- and while-statements were not visible inside the blocks. Now, the scopes are only created once as intended, rather than re-created for each and every statement inside the scope block.